### PR TITLE
Fix problem where date comparison always yields a patch.

### DIFF
--- a/src/json-patch-duplex.js
+++ b/src/json-patch-duplex.js
@@ -222,6 +222,7 @@ var jsonpatch;
     jsonpatch.generate = generate;
     // Dirty check if obj is different from mirror, generate patches and update mirror
     function _generate(mirror, obj, patches, path) {
+        obj = JSON.parse(JSON.stringify(obj));
         var newKeys = Object.keys(obj);
         var oldKeys = Object.keys(mirror);
         var changed = false;


### PR DESCRIPTION
When you do a comparison on an object that includes dates, all dates end up resulting in patches. This is because JSON.parse(JSON.stringify)) is used to generate an internal cache object, but that does not result in an object with identical values. Dates get converted to strings:

d = new Date();
foo = {x: 10, y: "test", z: d};
jsonpatch.observe(foo);
bar = jsonpatch.observe(foo);
jsonpatch.generate(bar);

The proposed fix is imperfect insofar as it does not correct the date to string conversion but instead just rolls with it by giving the object variable to be compared against the original cached version the same treatment. This works for us, and probably most people, because the end goal is to generate JSON patches to be transmitted as text where the dates will end up becoming strings anyway.

This is a really simple and slick implementation of rfc6902 by the way. Thanks for publishing it.
