### PR TITLE
Add compare function to CommonJS exports

### DIFF
--- a/src/json-patch-duplex.ts
+++ b/src/json-patch-duplex.ts
@@ -497,4 +497,5 @@ if (typeof exports !== "undefined") {
   exports.observe = jsonpatch.observe;
   exports.unobserve = jsonpatch.unobserve;
   exports.generate = jsonpatch.generate;
+  exports.compare = jsonpatch.compare;
 }


### PR DESCRIPTION
It was there for global, but missing for cjs exports.
