### PR TITLE
Differentiates arrays and objects

### DIFF
--- a/src/json-patch-duplex.js
+++ b/src/json-patch-duplex.js
@@ -396,6 +396,11 @@ var jsonpatch;
             }
         }
 
+        if (!newKeys.length && newKeys.length === oldKeys.length) {
+            if (mirror.length !== obj.length) {
+                patches.push({ op: "replace", path: path + "/", value: obj });
+            }
+        }
         if (!deleted && newKeys.length == oldKeys.length) {
             return;
         }


### PR DESCRIPTION
Start of a solution to #31.

This begins the process of differentiating between arrays and objects. The fix in this PR only compares empty ones, though. It'll likely take a different sort of refactor to handle all cases.

To test:

```js
// On master, you get nothing.
jsonpatch.compare({a: {}}, {a: []});

// On this branch, you get a nice replace. Yippee
```