### PR TITLE
Fix error when some properties of observed object are functions

### DIFF
--- a/src/json-patch-duplex.js
+++ b/src/json-patch-duplex.js
@@ -491,7 +491,9 @@ var jsonpatch;
             var key = newKeys[t];
             if (!mirror.hasOwnProperty(key)) {
                 patches.push({ op: "add", path: path + "/" + escapePathComponent(key), value: obj[key] });
-                mirror[key] = JSON.parse(JSON.stringify(obj[key]));
+                if (typeof obj[key] !== 'function') {
+                    mirror[key] = JSON.parse(JSON.stringify(obj[key]));
+                }
             }
         }
     }


### PR DESCRIPTION
I was trying to observe changes of an object in which some properties are functions. So `JSON.stringify(obj[key])` returns `undefined` and JSON.parse throws an exception.
Adding a test fix the exception.
