### PR TITLE
Safety change to json-patch-duplex.js

### DIFF
--- a/src/json-patch-duplex.js
+++ b/src/json-patch-duplex.js
@@ -479,7 +479,7 @@ var jsonpatch;
             var oldVal = mirror[key];
             if (obj.hasOwnProperty(key)) {
                 var newVal = obj[key];
-                if (oldVal instanceof Object) {
+                if (oldVal instanceof Object && newVal instanceof Object) {
                     _generate(oldVal, newVal, patches, path + "/" + escapePathComponent(key));
                 } else {
                     if (oldVal != newVal) {


### PR DESCRIPTION
if oldVal is an object and newVal is a string or any other primitive type a typeError exception is thrown by the Object.Keys function.  This is a simple safety check to avoid the exception.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys
