### PR TITLE
Replace bower main file with the appropriate duplex implementation

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "0.5.0",
   "homepage": "https://github.com/Starcounter-Jack/Fast-JSON-Patch",
   "description": "Fast implementation of JSON-Patch (RFC-6902) with duplex (observe changes) capabilities",
-  "main": "src/json-patch.js",
+  "main": "src/json-patch-duplex.js",
   "keywords": ["json", "patch", "http", "rest"],
   "license": "MIT",
   "ignore": [


### PR DESCRIPTION
Hey,

I'd like to replace the current bower main file (`json-patch.js`) with the duplexed implementation. My rationale is that the bower main file should point to the file that is most useful for a browser implementation. As the browsers typical role in a RESTful setup is to generate patches it's useful to have `observe` and friends at hand.

Thank you for your time,

Johannes