### PR TITLE
Changed deletions for remove operations to setting undefined.

### DIFF
--- a/src/json-patch-duplex.js
+++ b/src/json-patch-duplex.js
@@ -89,7 +89,7 @@ var jsonpatch;
             return true;
         },
         remove: function (obj, key) {
-            delete obj[key];
+            obj[key] = undefined;
             return true;
         },
         replace: function (obj, key) {

--- a/src/json-patch-duplex.ts
+++ b/src/json-patch-duplex.ts
@@ -90,7 +90,7 @@ module jsonpatch {
       return true;
     },
     remove: function (obj, key) {
-      delete obj[key];
+      obj[key] = undefined;
       return true;
     },
     replace: function (obj, key) {

--- a/src/json-patch.js
+++ b/src/json-patch.js
@@ -88,7 +88,7 @@ var jsonpatch;
             return true;
         },
         remove: function (obj, key) {
-            delete obj[key];
+            obj[key] = undefined;
             return true;
         },
         replace: function (obj, key) {

--- a/src/json-patch.ts
+++ b/src/json-patch.ts
@@ -83,7 +83,7 @@ module jsonpatch {
       return true;
     },
     remove: function (obj, key) {
-      delete obj[key];
+      obj[key] = undefined;
       return true;
     },
     replace: function (obj, key) {


### PR DESCRIPTION
@Starcounter-Jack I don't expect this PR to actually be merged, I just wanted to discuss some of the implications of this.

I'm using [Mongoose](https://github.com/Automattic/mongoose) and have written a little [plugin](https://github.com/winduptoy/mongoose-json-patch) that will accept patches, apply them to Mongoose documents and then persist them to the database.

Mongoose is built with getters and setters and observes your object properties, so `delete`ing a key will not trigger a setter, so the key isn't removed from the database. Setting `undefined` will trigger the setter, and correctly remove it from the database.

I was wondering what downsides there would be to doing this. Would it be feasible to have an option that would switch between `delete` mode and `= undefined` mode?