### PR TITLE
Apply patch to blank object.

### DIFF
--- a/src/json-patch-duplex.js
+++ b/src/json-patch-duplex.js
@@ -598,6 +598,7 @@ var jsonpatch;
                         break;
                     }
                 }
+                obj[key] = obj[key] || (isNaN(parseInt(keys[t], 10)) ? {} : []);
                 obj = obj[key];
             }
         }


### PR DESCRIPTION
I'm fetching document from ElasticSearch, then on the frontend i'm applying modifications to the document and I need to send back the document that contains only the changes, but not as JSON Patch, but as a partial document.

So I'm simply applying the json patch to blank object.