### PR TITLE
Fix for "apply" with escaped characters in path when validation is enabled

### DIFF
--- a/src/json-patch-duplex.js
+++ b/src/json-patch-duplex.js
@@ -445,6 +445,10 @@ var jsonpatch;
             var existingPathFragment = undefined;
             while (true) {
                 key = keys[t];
+                if (key && key.indexOf('~') != -1) {
+                    key = key.replace(/~1/g, '/').replace(/~0/g, '~'); // escape chars
+                }
+
                 if (validate) {
                     if (existingPathFragment === undefined) {
                         if (obj[key] === undefined) {

--- a/src/json-patch-duplex.ts
+++ b/src/json-patch-duplex.ts
@@ -498,6 +498,9 @@ module jsonpatch {
 
       while (true) {
         key = keys[t];
+        if (key && key.indexOf('~') != -1) {
+            key = key.replace(/~1/g, '/').replace(/~0/g, '~'); // escape chars
+        }
 
         if (validate) {
           if (existingPathFragment === undefined) {

--- a/src/json-patch.js
+++ b/src/json-patch.js
@@ -196,6 +196,10 @@ var jsonpatch;
             var existingPathFragment = undefined;
             while (true) {
                 key = keys[t];
+                if (key && key.indexOf('~') != -1) {
+                    key = key.replace(/~1/g, '/').replace(/~0/g, '~'); // escape chars
+                }
+
                 if (validate) {
                     if (existingPathFragment === undefined) {
                         if (obj[key] === undefined) {

--- a/src/json-patch.ts
+++ b/src/json-patch.ts
@@ -210,6 +210,9 @@ module jsonpatch {
 
       while (true) {
         key = keys[t];
+        if (key && key.indexOf('~') != -1) {
+            key = key.replace(/~1/g, '/').replace(/~0/g, '~'); // escape chars
+        }
 
         if (validate) {
           if (existingPathFragment === undefined) {

--- a/test/spec/coreSpec.js
+++ b/test/spec/coreSpec.js
@@ -71,6 +71,14 @@ describe("core", function () {
     expect(obj).toEqual({"hello": "universe"});
   });
 
+  it('should apply replace (with validation) on path with escaped characters', function() {
+    var obj = {"a/b": "old"};
+
+    var error = jsonpatch.apply(obj, [{"op":"replace", "path": "/a~1b", "value": "new"}], true);
+
+    expect(obj["a/b"]).toBe("new");
+  });
+
 
   it('should apply test', function() {
     obj = {


### PR DESCRIPTION
Fix for "apply" with ~1 and ~0 in path when validation is enabled.

Repro steps are shown in unit test.
