### PR TITLE
Issue 114

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "http://www.starcounter.com/"
   },
   "license": "MIT",
-  "main": "./src/json-patch-duplex",
+  "main": "./src/json-patch-duplex.js",
   "engines": {
     "node": ">= 0.4.0"
   },


### PR DESCRIPTION
Fixed reference to 'main' so that the .js file is referenced. This resolves an issue where someone imports the module using the tsc but doesn't have the right typings setup.