### PR TITLE
Adding validation for paths starting with "/". Fixes issue #77.

### DIFF
--- a/src/json-patch-duplex.js
+++ b/src/json-patch-duplex.js
@@ -531,6 +531,10 @@ var jsonpatch;
         else if (typeof operation.path !== 'string') {
             throw new JsonPatchError('Operation `path` property is not a string', 'OPERATION_PATH_INVALID', index, operation, tree);
         }
+        else if (operation.path.indexOf('/') !== 0 && operation.path.length > 0) {
+            // paths that aren't emptystring should start with "/"
+            throw new JsonPatchError('Operation `path` property must start with "/"', 'OPERATION_PATH_INVALID', index, operation, tree);
+        }
         else if ((operation.op === 'move' || operation.op === 'copy') && typeof operation.from !== 'string') {
             throw new JsonPatchError('Operation `from` property is not present (applicable in `move` and `copy` operations)', 'OPERATION_FROM_REQUIRED', index, operation, tree);
         }

--- a/src/json-patch-duplex.ts
+++ b/src/json-patch-duplex.ts
@@ -589,6 +589,11 @@ module jsonpatch {
     else if (typeof operation.path !== 'string') {
       throw new JsonPatchError('Operation `path` property is not a string', 'OPERATION_PATH_INVALID', index, operation, tree);
     }
+    
+    else if (operation.path.indexOf('/') !== 0 && operation.path.length > 0) {
+      // paths that aren't emptystring should start with "/"
+      throw new JsonPatchError('Operation `path` property must start with "/"', 'OPERATION_PATH_INVALID', index, operation, tree);
+    }
 
     else if ((operation.op === 'move' || operation.op === 'copy') && typeof operation.from !== 'string') {
       throw new JsonPatchError('Operation `from` property is not present (applicable in `move` and `copy` operations)', 'OPERATION_FROM_REQUIRED', index, operation, tree);

--- a/src/json-patch.js
+++ b/src/json-patch.js
@@ -316,6 +316,10 @@ var jsonpatch;
         else if (typeof operation.path !== 'string') {
             throw new JsonPatchError('Operation `path` property is not a string', 'OPERATION_PATH_INVALID', index, operation, tree);
         }
+        else if (operation.path.indexOf('/') !== 0 && operation.path.length > 0) {
+            // paths that aren't emptystring should start with "/"
+            throw new JsonPatchError('Operation `path` property must start with "/"', 'OPERATION_PATH_INVALID', index, operation, tree);
+        }
         else if ((operation.op === 'move' || operation.op === 'copy') && typeof operation.from !== 'string') {
             throw new JsonPatchError('Operation `from` property is not present (applicable in `move` and `copy` operations)', 'OPERATION_FROM_REQUIRED', index, operation, tree);
         }

--- a/src/json-patch.ts
+++ b/src/json-patch.ts
@@ -341,6 +341,11 @@ module jsonpatch {
       throw new JsonPatchError('Operation `path` property is not a string', 'OPERATION_PATH_INVALID', index, operation, tree);
     }
 
+    else if (operation.path.indexOf('/') !== 0 && operation.path.length > 0) {
+      // paths that aren't emptystring should start with "/"
+      throw new JsonPatchError('Operation `path` property must start with "/"', 'OPERATION_PATH_INVALID', index, operation, tree);
+    }
+
     else if ((operation.op === 'move' || operation.op === 'copy') && typeof operation.from !== 'string') {
       throw new JsonPatchError('Operation `from` property is not present (applicable in `move` and `copy` operations)', 'OPERATION_FROM_REQUIRED', index, operation, tree);
     }

--- a/test/spec/validateSpec.js
+++ b/test/spec/validateSpec.js
@@ -425,6 +425,22 @@ describe("validate", function() {
         expect(ex.name).toBe("OPERATION_PATH_INVALID");
     });
 
+    it('should throw OPERATION_PATH_INVALID when applying patch with an invalid path. Issue #77.', function() {
+        var a = {};
+        var ex = null;
+
+        try {
+            jsonpatch.apply(a, [{
+                op: "replace",
+                value: "",
+                path: "foo" // no preceding "/"
+            }], true);
+        } catch (e) {
+            ex = e;
+        }
+        expect(ex.name).toBe("OPERATION_PATH_INVALID");
+    });
+
     it('should throw OPERATION_OP_INVALID when applying patch without operation', function() {
         var a = {};
         var ex = null;


### PR DESCRIPTION
Adding a validation check for paths starting with "/". Note that this PR maintains the replace-all behavior when path is emptystring.

Fixes issue #77 