### PR TITLE
Fix for issue #123

### DIFF
--- a/src/json-patch-duplex.js
+++ b/src/json-patch-duplex.js
@@ -347,7 +347,7 @@ var jsonpatch;
         for (var t = oldKeys.length - 1; t >= 0; t--) {
             var key = oldKeys[t];
             var oldVal = mirror[key];
-            if (obj.hasOwnProperty(key) && !(obj[key] === undefined && _isArray(obj) === false)) {
+            if (obj.hasOwnProperty(key) && !(obj[key] === undefined && _isArray(obj) === false && oldVal !== undefined)) {
                 var newVal = obj[key];
                 if (typeof oldVal == "object" && oldVal != null && typeof newVal == "object" && newVal != null) {
                     _generate(oldVal, newVal, patches, path + "/" + escapePathComponent(key));

--- a/src/json-patch-duplex.ts
+++ b/src/json-patch-duplex.ts
@@ -395,7 +395,7 @@ module jsonpatch {
     for (var t = oldKeys.length - 1; t >= 0; t--) {
       var key = oldKeys[t];
       var oldVal = mirror[key];
-      if (obj.hasOwnProperty(key) && !(obj[key] === undefined && _isArray(obj) === false)) {
+      if (obj.hasOwnProperty(key) && !(obj[key] === undefined && _isArray(obj) === false && oldVal !== undefined)) {
         var newVal = obj[key];
         if (typeof oldVal == "object" && oldVal != null && typeof newVal == "object" && newVal != null) {
           _generate(oldVal, newVal, patches, path + "/" + escapePathComponent(key));

--- a/test/spec/duplexSpec.js
+++ b/test/spec/duplexSpec.js
@@ -1311,6 +1311,17 @@ describe("duplex", function() {
                 value: null
             }]);
         });
+
+        it('should not remove undefined', function() {
+            var objA = {
+                user: undefined
+            };
+            var objB = {
+                user: undefined
+            };
+
+            expect(jsonpatch.compare(objA, objB)).toReallyEqual([]);
+        })
     });
 
 


### PR DESCRIPTION
There's logic to always assume that if `newObject[key]` is `undefined`, then that key must have been removed. If `oldObject[key]` is also `undefined`, though, that's not true.

Fixes #123.