### PR TITLE
Publish `.d.ts` files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,6 +5,7 @@ examples/
 test/
 .travis.yml
 *.ts
+!*.d.ts
 
 # Mac OS X
 .DS_Store


### PR DESCRIPTION
Fixes #156 
The `package.json` already contains `"typings": "src/json-patch-duplex.d.ts"`, so that file should be published to NPM too!
