### PR TITLE
Rename Patch to Operation

### DIFF
--- a/src/json-patch-duplex.d.ts
+++ b/src/json-patch-duplex.d.ts
@@ -72,9 +72,9 @@ declare module jsonpatch {
     class JsonPatchError extends Error {
         message: string;
         name: JsonPatchErrorName;
-        index?: number;
-        operation?: any;
-        tree?: any;
+        index: number;
+        operation: any;
+        tree: any;
         constructor(message: string, name: JsonPatchErrorName, index?: number, operation?: any, tree?: any);
     }
     /**

--- a/src/json-patch.d.ts
+++ b/src/json-patch.d.ts
@@ -4,55 +4,84 @@
  * (c) 2013 Joachim Wester
  * MIT license
  */
-declare module jsonpatch {
-    type Patch<T> = AddPatch<T> | RemovePatch | ReplacePatch<T> | MovePatch | CopyPatch | TestPatch<T>;
-    interface PatchBase {
+declare namespace jsonpatch {
+    type Operation = AddOperation<any> | RemoveOperation | ReplaceOperation<any> | MoveOperation | CopyOperation | TestOperation<any>;
+    interface BaseOperation {
         path: string;
     }
-    interface AddPatch<T> extends PatchBase {
+    interface AddOperation<T> extends BaseOperation {
         op: 'add';
         value: T;
     }
-    interface RemovePatch extends PatchBase {
+    interface RemoveOperation extends BaseOperation {
         op: 'remove';
     }
-    interface ReplacePatch<T> extends PatchBase {
+    interface ReplaceOperation<T> extends BaseOperation {
         op: 'replace';
         value: T;
     }
-    interface MovePatch extends PatchBase {
+    interface MoveOperation extends BaseOperation {
         op: 'move';
         from: string;
     }
-    interface CopyPatch extends PatchBase {
+    interface CopyOperation extends BaseOperation {
         op: 'copy';
         from: string;
     }
-    interface TestPatch<T> extends PatchBase {
+    interface TestOperation<T> extends BaseOperation {
         op: 'test';
         value: T;
     }
+    /** DEPRECATED. Use `Operation` */
+    type Patch<T> = Operation;
+    /** DEPRECATED. Use `AddOperation` */
+    type AddPatch<T> = AddOperation<T>;
+    /** DEPRECATED. Use `RemoveOperation` */
+    type RemovePatch = RemoveOperation;
+    /** DEPRECATED. Use `ReplaceOperation` */
+    type ReplacePatch<T> = ReplaceOperation<T>;
+    /** DEPRECATED. Use `MoveOperation` */
+    type MovePatch = MoveOperation;
+    /** DEPRECATED. Use `CopyOperation` */
+    type CopyPatch = CopyOperation;
+    /** DEPRECATED. Use `TestOperation` */
+    type TestPatch<T> = TestOperation<T>;
     type JsonPatchErrorName = 'SEQUENCE_NOT_AN_ARRAY' | 'OPERATION_NOT_AN_OBJECT' | 'OPERATION_OP_INVALID' | 'OPERATION_PATH_INVALID' | 'OPERATION_FROM_REQUIRED' | 'OPERATION_VALUE_REQUIRED' | 'OPERATION_VALUE_CANNOT_CONTAIN_UNDEFINED' | 'OPERATION_PATH_CANNOT_ADD' | 'OPERATION_PATH_UNRESOLVABLE' | 'OPERATION_FROM_UNRESOLVABLE' | 'OPERATION_PATH_ILLEGAL_ARRAY_INDEX' | 'OPERATION_VALUE_OUT_OF_BOUNDS' | 'TEST_OPERATION_FAILED';
     /**
-       * Apply a single json-patch on an object tree
-       * Returns the result object.
-       */
-    function applyPatch<T>(tree: T, patch: Patch<any>): T;
-    function applyPatch<T>(tree: T, patch: Patch<any>, validate: boolean, touchOriginalTree: boolean): T;
+     * Apply a single JSON Patch Operation on a JSON document.
+     * Returns the updated document.
+     * Suitable as a reducer.
+     *
+     * @param document The document to patch
+     * @param operation The operation to apply
+     * @return The updated document
+     */
+    function applyOperation<T>(document: T, operation: Operation): T;
     /**
-     * Apply a json-patch operation on an object tree
+     * Apply a single JSON Patch Operation on a JSON document.
+     * Returns the updated document.
+     *
+     * @param document The document to patch
+     * @param operation The operation to apply
+     * @param validate Whether to validate the operation
+     * @param mutateDocument Whether to mutate the original document or clone it before applying
+     * @return The updated document
+     */
+    function applyOperation<T>(document: T, operation: Operation, validate: boolean, mutateDocument: boolean): T;
+    /**
+     * Apply a JSON Patch on a JSON document.
      * Returns an array of results of operations.
      * Each element can either be a boolean (if op == 'test') or
      * the removed object (operations that remove things)
      * or just be undefined
      */
-    function apply(tree: any, patches: Patch<any>[], validate?: boolean): any[];
+    function apply(document: any, patch: Operation[], validate?: boolean): any[];
     class JsonPatchError extends Error {
         message: string;
         name: JsonPatchErrorName;
-        index?: number;
-        operation?: any;
-        tree?: any;
+        index: number;
+        operation: any;
+        tree: any;
         constructor(message: string, name: JsonPatchErrorName, index?: number, operation?: any, tree?: any);
     }
     /**
@@ -62,14 +91,14 @@ declare module jsonpatch {
      * @param {object} [tree] - object where the operation is supposed to be applied
      * @param {string} [existingPathFragment] - comes along with `tree`
      */
-    function validator(operation: Patch<any>, index: number, tree?: any, existingPathFragment?: string): void;
+    function validator(operation: Operation, index: number, document?: any, existingPathFragment?: string): void;
     /**
-     * Validates a sequence of operations. If `tree` parameter is provided, the sequence is additionally validated against the object tree.
+     * Validates a sequence of operations. If `operation` parameter is provided, the sequence is additionally validated against the object tree.
      * If error is encountered, returns a JsonPatchError object
-     * @param sequence
-     * @param tree
+     * @param patch
+     * @param document
      * @returns {JsonPatchError|undefined}
      */
-    function validate(sequence: Patch<any>[], tree?: any): JsonPatchError;
+    function validate(patch: Operation[], document?: any): JsonPatchError | undefined;
 }
 export default jsonpatch;

--- a/src/json-patch.ts
+++ b/src/json-patch.ts
@@ -370,7 +370,7 @@ namespace jsonpatch {
     let operation: Operation;
     let key: string | number;
     while (p < plen) {
-      operation = operation[p];
+      operation = patch[p];
       p++;
       // Find the object
       var path = operation.path || "";

--- a/src/json-patch.ts
+++ b/src/json-patch.ts
@@ -5,41 +5,58 @@
  * MIT license
  */
 
-module jsonpatch {
-  export type Patch<T> = AddPatch<T> | RemovePatch | ReplacePatch<T> | MovePatch | CopyPatch | TestPatch<T>;
+namespace jsonpatch {
+  export type Operation = AddOperation<any> | RemoveOperation | ReplaceOperation<any> | MoveOperation | CopyOperation | TestOperation<any>;
 
-  export interface PatchBase {
+  export interface BaseOperation {
     path: string;
   }
 
-  export interface AddPatch<T> extends PatchBase {
+  export interface AddOperation<T> extends BaseOperation {
     op: 'add';
     value: T;
   }
 
-  export interface RemovePatch extends PatchBase {
+  export interface RemoveOperation extends BaseOperation {
     op: 'remove';
   }
 
-  export interface ReplacePatch<T> extends PatchBase {
+  export interface ReplaceOperation<T> extends BaseOperation {
     op: 'replace';
     value: T;
   }
 
-  export interface MovePatch extends PatchBase {
+  export interface MoveOperation extends BaseOperation {
     op: 'move';
     from: string;
   }
 
-  export interface CopyPatch extends PatchBase {
+  export interface CopyOperation extends BaseOperation {
     op: 'copy';
     from: string;
   }
 
-  export interface TestPatch<T> extends PatchBase {
+  export interface TestOperation<T> extends BaseOperation {
     op: 'test';
     value: T;
   }
+
+  // Aliases for BC
+
+  /** DEPRECATED. Use `Operation` */
+  export type Patch<T> = Operation;
+  /** DEPRECATED. Use `AddOperation` */
+  export type AddPatch<T> = AddOperation<T>;
+  /** DEPRECATED. Use `RemoveOperation` */
+  export type RemovePatch = RemoveOperation;
+  /** DEPRECATED. Use `ReplaceOperation` */
+  export type ReplacePatch<T> = ReplaceOperation<T>;
+  /** DEPRECATED. Use `MoveOperation` */
+  export type MovePatch = MoveOperation;
+  /** DEPRECATED. Use `CopyOperation` */
+  export type CopyPatch = CopyOperation;
+  /** DEPRECATED. Use `TestOperation` */
+  export type TestPatch<T> = TestOperation<T>;
 
   export type JsonPatchErrorName = 'SEQUENCE_NOT_AN_ARRAY' |
     'OPERATION_NOT_AN_OBJECT' |
@@ -268,82 +285,97 @@ module jsonpatch {
     return true;
   }
   /**
-     * Apply a single json-patch on an object tree
-     * Returns the result object.
-     */
-  export function applyPatch<T>(tree: T, patch: Patch<any>): T;
-  export function applyPatch<T>(tree: T, patch: Patch<any>, validate: boolean, touchOriginalTree: boolean): T;
-  export function applyPatch<T>(tree: T, patch: Patch<any>, validate = false, touchOriginalTree = true): T {
+   * Apply a single JSON Patch Operation on a JSON document.
+   * Returns the updated document.
+   * Suitable as a reducer.
+   * 
+   * @param document The document to patch
+   * @param operation The operation to apply
+   * @return The updated document
+   */
+  export function applyOperation<T>(document: T, operation: Operation): T;
+  /**
+   * Apply a single JSON Patch Operation on a JSON document.
+   * Returns the updated document.
+   * 
+   * @param document The document to patch
+   * @param operation The operation to apply
+   * @param validate Whether to validate the operation
+   * @param mutateDocument Whether to mutate the original document or clone it before applying
+   * @return The updated document
+   */
+  export function applyOperation<T>(document: T, operation: Operation, validate: boolean, mutateDocument: boolean): T;
+  export function applyOperation<T>(document: T, operation: Operation, validate = false, mutateDocument = true): T {
     if (typeof validate !== 'boolean') { // if validate is not a boolean, it's being called from `reduce`
       validate = false;
-      touchOriginalTree = true;
+      mutateDocument = true;
     }
     // on root
-    if (patch.path === "") {
-      if (patch.op === 'add' || patch.op === 'replace') {// same for add or replace 
-        return patch.value;
-      } else if (patch.op === 'move' || patch.op === 'copy') { // it's a move or copy to root
+    if (operation.path === "") {
+      if (operation.op === 'add' || operation.op === 'replace') {// same for add or replace 
+        return operation.value;
+      } else if (operation.op === 'move' || operation.op === 'copy') { // it's a move or copy to root
         // get the value by json-pointer in `from` field
-        const temp: any = { op: "_get", path: patch.from };
-        apply(tree, [temp]);
+        const temp: any = { op: "_get", path: operation.from };
+        apply(document, [temp]);
         return temp.value;
       } else { // it's a remove or test on root
-        if (patch.op === 'test') {
-          if(_equals(tree, patch.value)) {
-            return tree;
+        if (operation.op === 'test') {
+          if(_equals(document, operation.value)) {
+            return document;
           } else {
-            throw new JsonPatchError('Test operation failed', 'TEST_OPERATION_FAILED', 0, patch, tree);
+            throw new JsonPatchError('Test operation failed', 'TEST_OPERATION_FAILED', 0, operation, document);
           }
-        } else if(patch.op === 'remove')  { // a remove on root
+        } else if(operation.op === 'remove')  { // a remove on root
           return null;
         } else { /* bad operation */
           if(validate) {
-              throw new JsonPatchError('Operation `op` property is not one of operations defined in RFC-6902', 'OPERATION_OP_INVALID', 0, patch, tree);
+              throw new JsonPatchError('Operation `op` property is not one of operations defined in RFC-6902', 'OPERATION_OP_INVALID', 0, operation, document);
           } else {
-            return tree;
+            return document;
           }
         }
       }
     } else {  // test operation 
-      if (patch.op === 'test') {
-        const results = apply(tree, [patch], validate);
+      if (operation.op === 'test') {
+        const results = apply(document, [operation], validate);
         if(results[0]) {
-          return tree;
+          return document;
         } else {
-          throw new JsonPatchError('Test operation failed', 'TEST_OPERATION_FAILED', 0, patch, tree);
+          throw new JsonPatchError('Test operation failed', 'TEST_OPERATION_FAILED', 0, operation, document);
         }
       }
       else {
-        if(typeof tree === 'object' && tree !== null) {          
-          !touchOriginalTree && (tree = deepClone(tree)); // keep the original tree untouched
-          apply(tree, [patch], validate);
-          return tree;
+        if(typeof document === 'object' && document !== null) {          
+          !mutateDocument && (document = deepClone(document)); // keep the original tree untouched
+          apply(document, [operation], validate);
+          return document;
         } else { // tree is a primitive or null;
-          return tree;
+          return document;
         }       
       }
     }
   }
   /**
-   * Apply a json-patch operation on an object tree
+   * Apply a JSON Patch on a JSON document.
    * Returns an array of results of operations.
    * Each element can either be a boolean (if op == 'test') or
    * the removed object (operations that remove things)
    * or just be undefined
    */
-  export function apply(tree: any, patches: Patch<any>[], validate?: boolean): any[] {
-    var results = new Array(patches.length)
-      , p = 0
-      , plen = patches.length
-      , patch
-      , key;
+  export function apply(document: any, patch: Operation[], validate?: boolean): any[] {
+    const results = new Array(patch.length);
+    let p = 0;
+    let plen = patch.length;
+    let operation: Operation;
+    let key: string | number;
     while (p < plen) {
-      patch = patches[p];
+      operation = operation[p];
       p++;
       // Find the object
-      var path = patch.path || "";
+      var path = operation.path || "";
       var keys = path.split('/');
-      var obj = tree;
+      var obj = document;
       var t = 1; //skip empty element - http://jsperf.com/to-shift-or-not-to-shift
       var len = keys.length;
       var existingPathFragment = undefined;
@@ -357,10 +389,10 @@ module jsonpatch {
               existingPathFragment = keys.slice(0, t).join('/');
             }
             else if (t == len - 1) {
-              existingPathFragment = patch.path;
+              existingPathFragment = operation.path;
             }
             if (existingPathFragment !== undefined) {
-              this.validator(patch, p - 1, tree, existingPathFragment);
+              this.validator(operation, p - 1, document, existingPathFragment);
             }
           }
         }
@@ -368,7 +400,7 @@ module jsonpatch {
         t++;
         if (key === undefined) { //is root
           if (t >= len) {
-            results[p - 1] = rootOps[patch.op].call(patch, obj, key, tree); // Apply patch
+            results[p - 1] = rootOps[operation.op].call(operation, obj, key, document); // Apply patch
             break;
           }
         }
@@ -378,15 +410,15 @@ module jsonpatch {
           }
           else {
             if (validate && !isInteger(key)) {
-              throw new JsonPatchError("Expected an unsigned base-10 integer value, making the new referenced value the array element with the zero-based index", "OPERATION_PATH_ILLEGAL_ARRAY_INDEX", p - 1, patch.path, patch);
+              throw new JsonPatchError("Expected an unsigned base-10 integer value, making the new referenced value the array element with the zero-based index", "OPERATION_PATH_ILLEGAL_ARRAY_INDEX", p - 1, operation.path, operation);
             }
             key = parseInt(key, 10);
           }
           if (t >= len) {
-            if (validate && patch.op === "add" && key > obj.length) {
-              throw new JsonPatchError("The specified index MUST NOT be greater than the number of elements in the array", "OPERATION_VALUE_OUT_OF_BOUNDS", p - 1, patch.path, patch);
+            if (validate && operation.op === "add" && key > obj.length) {
+              throw new JsonPatchError("The specified index MUST NOT be greater than the number of elements in the array", "OPERATION_VALUE_OUT_OF_BOUNDS", p - 1, operation.path, operation);
             }
-            results[p - 1] = arrOps[patch.op].call(patch, obj, key, tree); // Apply patch
+            results[p - 1] = arrOps[operation.op].call(operation, obj, key, document); // Apply patch
             break;
           }
         }
@@ -394,7 +426,7 @@ module jsonpatch {
           if (key && key.indexOf('~') != -1)
             key = key.replace(/~1/g, '/').replace(/~0/g, '~'); // escape chars
           if (t >= len) {
-            results[p - 1] = objOps[patch.op].call(patch, obj, key, tree); // Apply patch
+            results[p - 1] = objOps[operation.op].call(operation, obj, key, document); // Apply patch
             break;
           }
         }
@@ -452,79 +484,79 @@ module jsonpatch {
    * @param {object} [tree] - object where the operation is supposed to be applied
    * @param {string} [existingPathFragment] - comes along with `tree`
    */
-  export function validator(operation: Patch<any>, index: number, tree?: any, existingPathFragment?: string) {
+  export function validator(operation: Operation, index: number, document?: any, existingPathFragment?: string): void {
     if (typeof operation !== 'object' || operation === null || _isArray(operation)) {
-      throw new JsonPatchError('Operation is not an object', 'OPERATION_NOT_AN_OBJECT', index, operation, tree);
+      throw new JsonPatchError('Operation is not an object', 'OPERATION_NOT_AN_OBJECT', index, operation, document);
     }
 
     else if (!objOps[operation.op]) {
-      throw new JsonPatchError('Operation `op` property is not one of operations defined in RFC-6902', 'OPERATION_OP_INVALID', index, operation, tree);
+      throw new JsonPatchError('Operation `op` property is not one of operations defined in RFC-6902', 'OPERATION_OP_INVALID', index, operation, document);
     }
 
     else if (typeof operation.path !== 'string') {
-      throw new JsonPatchError('Operation `path` property is not a string', 'OPERATION_PATH_INVALID', index, operation, tree);
+      throw new JsonPatchError('Operation `path` property is not a string', 'OPERATION_PATH_INVALID', index, operation, document);
     }
 
     else if (operation.path.indexOf('/') !== 0 && operation.path.length > 0) {
       // paths that aren't emptystring should start with "/"
-      throw new JsonPatchError('Operation `path` property must start with "/"', 'OPERATION_PATH_INVALID', index, operation, tree);
+      throw new JsonPatchError('Operation `path` property must start with "/"', 'OPERATION_PATH_INVALID', index, operation, document);
     }
 
     else if ((operation.op === 'move' || operation.op === 'copy') && typeof operation.from !== 'string') {
-      throw new JsonPatchError('Operation `from` property is not present (applicable in `move` and `copy` operations)', 'OPERATION_FROM_REQUIRED', index, operation, tree);
+      throw new JsonPatchError('Operation `from` property is not present (applicable in `move` and `copy` operations)', 'OPERATION_FROM_REQUIRED', index, operation, document);
     }
 
     else if ((operation.op === 'add' || operation.op === 'replace' || operation.op === 'test') && operation.value === undefined) {
-      throw new JsonPatchError('Operation `value` property is not present (applicable in `add`, `replace` and `test` operations)', 'OPERATION_VALUE_REQUIRED', index, operation, tree);
+      throw new JsonPatchError('Operation `value` property is not present (applicable in `add`, `replace` and `test` operations)', 'OPERATION_VALUE_REQUIRED', index, operation, document);
     }
 
     else if ((operation.op === 'add' || operation.op === 'replace' || operation.op === 'test') && hasUndefined(operation.value)) {
-      throw new JsonPatchError('Operation `value` property is not present (applicable in `add`, `replace` and `test` operations)', 'OPERATION_VALUE_CANNOT_CONTAIN_UNDEFINED', index, operation, tree);
+      throw new JsonPatchError('Operation `value` property is not present (applicable in `add`, `replace` and `test` operations)', 'OPERATION_VALUE_CANNOT_CONTAIN_UNDEFINED', index, operation, document);
     }
 
-    else if (tree) {
+    else if (document) {
       if (operation.op == "add") {
         var pathLen = operation.path.split("/").length;
         var existingPathLen = existingPathFragment.split("/").length;
         if (pathLen !== existingPathLen + 1 && pathLen !== existingPathLen) {
-          throw new JsonPatchError('Cannot perform an `add` operation at the desired path', 'OPERATION_PATH_CANNOT_ADD', index, operation, tree);
+          throw new JsonPatchError('Cannot perform an `add` operation at the desired path', 'OPERATION_PATH_CANNOT_ADD', index, operation, document);
         }
       }
       else if (operation.op === 'replace' || operation.op === 'remove' || (<any>operation.op) === '_get') {
         if (operation.path !== existingPathFragment) {
-          throw new JsonPatchError('Cannot perform the operation at a path that does not exist', 'OPERATION_PATH_UNRESOLVABLE', index, operation, tree);
+          throw new JsonPatchError('Cannot perform the operation at a path that does not exist', 'OPERATION_PATH_UNRESOLVABLE', index, operation, document);
         }
       }
       else if (operation.op === 'move' || operation.op === 'copy') {
         var existingValue: any = { op: "_get", path: operation.from, value: undefined };
-        var error = jsonpatch.validate([existingValue], tree);
+        var error = jsonpatch.validate([existingValue], document);
         if (error && error.name === 'OPERATION_PATH_UNRESOLVABLE') {
-          throw new JsonPatchError('Cannot perform the operation from a path that does not exist', 'OPERATION_FROM_UNRESOLVABLE', index, operation, tree);
+          throw new JsonPatchError('Cannot perform the operation from a path that does not exist', 'OPERATION_FROM_UNRESOLVABLE', index, operation, document);
         }
       }
     }
   }
 
   /**
-   * Validates a sequence of operations. If `tree` parameter is provided, the sequence is additionally validated against the object tree.
+   * Validates a sequence of operations. If `operation` parameter is provided, the sequence is additionally validated against the object tree.
    * If error is encountered, returns a JsonPatchError object
-   * @param sequence
-   * @param tree
+   * @param patch
+   * @param document
    * @returns {JsonPatchError|undefined}
    */
-  export function validate(sequence: Patch<any>[], tree?: any): JsonPatchError {
+  export function validate(patch: Operation[], document?: any): JsonPatchError | undefined {
     try {
-      if (!_isArray(sequence)) {
+      if (!_isArray(patch)) {
         throw new JsonPatchError('Patch sequence must be an array', 'SEQUENCE_NOT_AN_ARRAY');
       }
 
-      if (tree) {
-        tree = JSON.parse(JSON.stringify(tree)); //clone tree so that we can safely try applying operations
-        apply.call(this, tree, sequence, true);
+      if (document) {
+        document = JSON.parse(JSON.stringify(document)); //clone tree so that we can safely try applying operations
+        apply.call(this, document, patch, true);
       }
       else {
-        for (var i = 0; i < sequence.length; i++) {
-          this.validator(sequence[i], i);
+        for (var i = 0; i < patch.length; i++) {
+          this.validator(patch[i], i);
         }
       }
     }
@@ -542,7 +574,7 @@ module jsonpatch {
 if (typeof exports !== "undefined") {
   exports.apply = jsonpatch.apply;
   exports.validate = jsonpatch.validate;
-  exports.applyPatch = jsonpatch.applyPatch;
+  exports.applyOperation = jsonpatch.applyOperation;
   exports.validator = jsonpatch.validator;
   exports.JsonPatchError = jsonpatch.JsonPatchError;
 }


### PR DESCRIPTION
"patch" now always refers to an array of "operations".
Old types aliased for BC.

@alshakero 