### PR TITLE
Issues/76 deep clone 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,9 @@ Applies `patch` array on `obj`.
 
 An invalid patch results in throwing an error (see `jsonpatch.validate` for more information about the error object).
 
+It modifies the `document` object and `patch` - it gets the values by reference.
+If you would like to avoid touching your values, clone them: `jsonpatch.apply(document, jsonpatch.deepClone(patch))`.
+
 Returns an array of [`OperationResult`](#operationresult-type) objects - one item for each item in `patches`, each item is an object `{newDocument: any, test?: boolean, removed?: any}`.
 
 * `test` - boolean result of the test
@@ -199,6 +202,9 @@ Applies single operation object `operation` on `document`.
 - `validateOperation` Whether to validate the operation, or to pass a validator callback
 - `mutateDocument` Whether to mutate the original document or clone it before applying
 
+It modifies the `document` object and `operation` - it gets the values by reference.
+If you would like to avoid touching your values, clone them: `jsonpatch.apply(document, jsonpatch.deepClone(operation))`.
+
 Returns an [`OperationResult`](#operationresult-type) object `{newDocument: any, test?: boolean, removed?: any}`.
 
 - See [Validation notes](#validation-notes).
@@ -214,6 +220,12 @@ Applies single operation object `operation` on `document`.
 Returns the a modified document.
 
 Note: It throws `TEST_OPERATION_FAILED` error if `test` operation fails.
+
+#### `jsonpatch.deepClone(value: any): any`
+
+Available in *json-patch.js* and *json-patch-duplex.js*
+
+Returns deeply cloned value.
 
 #### `jsonpatch.escapePathComponent(path: string): string`
 

--- a/src/json-patch-duplex.d.ts
+++ b/src/json-patch-duplex.d.ts
@@ -81,6 +81,12 @@ declare module jsonpatch {
      */
     function generate<T>(observer: Observer<T>): Patch<any>[];
     /**
+     * Deeply clone the object.
+     * @param  {any} obj value to clone
+     * @return {any}       cloned obj
+     */
+    function deepClone(obj: any): any;
+    /**
     * Escapes a json pointer path
     * @param path The raw pointer
     * @return the Escaped path
@@ -104,35 +110,39 @@ declare module jsonpatch {
     /**
      * Apply a single JSON Patch Operation on a JSON document.
      * Returns the {newDocument, result} of the operation.
+     * It modifies the `document` object and `patch` - it gets the values by reference.
+     * If you would like to avoid touching your values, clone them:
+     * `jsonpatch.applyOperation(document, jsonpatch.deepClone(operation))`.
      *
      * @param document The document to patch
      * @param operation The operation to apply
      * @param validateOperation `false` is without validation, `true` to use default jsonpatch's validation, or you can pass a `validateOperation` callback to be used for validation.
      * @param mutateDocument Whether to mutate the original document or clone it before applying
-     * @param copyByValue Whether to copy operation `value` properties by value or reference
      * @return `{newDocument, result}` after the operation
      */
-    function applyOperation<T>(document: T, operation: Operation, validateOperation?: boolean | Validator<T>, mutateDocument?: boolean, copyByValue?: boolean): OperationResult<T>;
+    function applyOperation<T>(document: T, operation: Operation, validateOperation?: boolean | Validator<T>, mutateDocument?: boolean): OperationResult<T>;
     /**
      * Apply a full JSON Patch array on a JSON document.
      * Returns the {newDocument, result} of the patch.
+     * It modifies the `document` object and `patch` - it gets the values by reference.
+     * If you would like to avoid touching your values, clone them:
+     * `jsonpatch.apply(document, jsonpatch.deepClone(patch))`.
      *
      * @param document The document to patch
      * @param patch The patch to apply
      * @param validateOperation `false` is without validation, `true` to use default jsonpatch's validation, or you can pass a `validateOperation` callback to be used for validation.
-     * @param copyByValue Whether to copy operation `value` properties by value or reference
      * @return An array of `{newDocument, result}` after the patch
      */
-    function applyPatch<T>(document: T, patch: Operation[], validateOperation?: boolean | Validator<T>, copyByValue?: boolean): PatchResult<T>;
+    function applyPatch<T>(document: T, patch: Operation[], validateOperation?: boolean | Validator<T>): PatchResult<T>;
     /**
      * Apply a JSON Patch on a JSON document.
      * Returns an array of results of operations.
      * Each element can either be a boolean (if op == 'test') or
      * the removed object (operations that remove things)
-     * or just be undefined
+     * or just be undefined.
      * @deprecated
      */
-    function apply<T>(document: T, patch: Operation[], validateOperation?: boolean | Validator<T>, copyByValue?: boolean): any[];
+    function apply<T>(document: T, patch: Operation[], validateOperation?: boolean | Validator<T>): any[];
     /**
      * Apply a single JSON Patch Operation on a JSON document.
      * Returns the updated document.
@@ -146,9 +156,9 @@ declare module jsonpatch {
     class JsonPatchError extends Error {
         message: string;
         name: JsonPatchErrorName;
-        index?: number;
-        operation?: any;
-        tree?: any;
+        index: number;
+        operation: any;
+        tree: any;
         constructor(message: string, name: JsonPatchErrorName, index?: number, operation?: any, tree?: any);
     }
     /**

--- a/src/json-patch-duplex.d.ts
+++ b/src/json-patch-duplex.d.ts
@@ -109,9 +109,10 @@ declare module jsonpatch {
      * @param operation The operation to apply
      * @param validateOperation `false` is without validation, `true` to use default jsonpatch's validation, or you can pass a `validateOperation` callback to be used for validation.
      * @param mutateDocument Whether to mutate the original document or clone it before applying
+     * @param copyByValue Whether to copy operation `value` properties by value or reference
      * @return `{newDocument, result}` after the operation
      */
-    function applyOperation<T>(document: T, operation: Operation, validateOperation?: boolean | Validator<T>, mutateDocument?: boolean): OperationResult<T>;
+    function applyOperation<T>(document: T, operation: Operation, validateOperation?: boolean | Validator<T>, mutateDocument?: boolean, copyByValue?: boolean): OperationResult<T>;
     /**
      * Apply a full JSON Patch array on a JSON document.
      * Returns the {newDocument, result} of the patch.
@@ -119,9 +120,10 @@ declare module jsonpatch {
      * @param document The document to patch
      * @param patch The patch to apply
      * @param validateOperation `false` is without validation, `true` to use default jsonpatch's validation, or you can pass a `validateOperation` callback to be used for validation.
+     * @param copyByValue Whether to copy operation `value` properties by value or reference
      * @return An array of `{newDocument, result}` after the patch
      */
-    function applyPatch<T>(document: T, patch: Operation[], validateOperation?: boolean | Validator<T>): PatchResult<T>;
+    function applyPatch<T>(document: T, patch: Operation[], validateOperation?: boolean | Validator<T>, copyByValue?: boolean): PatchResult<T>;
     /**
      * Apply a JSON Patch on a JSON document.
      * Returns an array of results of operations.
@@ -130,7 +132,7 @@ declare module jsonpatch {
      * or just be undefined
      * @deprecated
      */
-    function apply<T>(document: T, patch: Operation[], validateOperation?: boolean | Validator<T>): any[];
+    function apply<T>(document: T, patch: Operation[], validateOperation?: boolean | Validator<T>, copyByValue?: boolean): any[];
     /**
      * Apply a single JSON Patch Operation on a JSON document.
      * Returns the updated document.

--- a/src/json-patch-duplex.ts
+++ b/src/json-patch-duplex.ts
@@ -174,6 +174,35 @@ module jsonpatch {
     }
   }
 
+  function _deepClone(value) {
+    // from here https://jsperf.com/deep-copy-vs-json-stringify-json-parse/25 (recursiveDeepCopy)
+    var clone;
+    var i;
+
+    if (typeof value !== 'object') {
+      return value;
+    }
+    if (!value) {
+      return value;
+    }
+
+    if ('[object Array]' === Object.prototype.toString.apply(value)) {
+      clone = [];
+      for (i = 0; i < value.length; i += 1) {
+        clone[i] = _deepClone(value[i]);
+      }
+      return clone;
+    }
+
+    clone = {};
+    for (i in value) {
+      if (value.hasOwnProperty(i)) {
+        clone[i] = _deepClone(value[i]);
+      }
+    }
+    return clone;
+  }
+
   /* We use a Javascript hash to store each
    function. Each hash entry (property) uses
    the operation identifiers specified in rfc6902.
@@ -184,7 +213,7 @@ module jsonpatch {
   /* The operations applicable to an object */
   const objOps = {
     add: function (obj, key, document) {
-      obj[key] = this.value;
+      obj[key] = _deepClone(this.value);
       return {newDocument: document};
     },
     remove: function (obj, key, document) {
@@ -194,7 +223,7 @@ module jsonpatch {
     },
     replace: function (obj, key, document) {
       var removed = obj[key];
-      obj[key] = this.value;
+      obj[key] = _deepClone(this.value);
       return {newDocument: document, removed};
     },
     move: function (obj, key, document) {
@@ -236,7 +265,7 @@ module jsonpatch {
   /* The operations applicable to an array. Many are the same as for the object */
   var arrOps = {
     add: function (arr, i, document) {
-      arr.splice(i, 0, this.value);
+      arr.splice(i, 0, _deepClone(this.value));
       // this may be needed when using '-' in an array
       return {newDocument: document, index: i}
     },
@@ -246,7 +275,7 @@ module jsonpatch {
     },
     replace: function (arr, i, document) {
       var removed = arr[i];
-      arr[i] = this.value;
+      arr[i] = _deepClone(this.value);
       return {newDocument: document, removed};
     },
     move: objOps.move,

--- a/src/json-patch-duplex.ts
+++ b/src/json-patch-duplex.ts
@@ -212,8 +212,8 @@ module jsonpatch {
 
   /* The operations applicable to an object */
   const objOps = {
-    add: function (obj, key, document) {
-      obj[key] = _deepClone(this.value);
+    add: function (obj, key, document, copyByValue) {
+      obj[key] = copyByValue ? _deepClone(this.value) : this.value;
       return {newDocument: document};
     },
     remove: function (obj, key, document) {
@@ -221,9 +221,9 @@ module jsonpatch {
       delete obj[key];
       return {newDocument: document, removed}
     },
-    replace: function (obj, key, document) {
+    replace: function (obj, key, document, copyByValue) {
       var removed = obj[key];
-      obj[key] = _deepClone(this.value);
+      obj[key] = copyByValue ? _deepClone(this.value) : this.value;
       return {newDocument: document, removed};
     },
     move: function (obj, key, document) {
@@ -248,8 +248,9 @@ module jsonpatch {
     },
     copy: function (obj, key, document) {
       const valueToCopy = getValueByPointer(document, this.from);
+      // enforce copy by value so further operations don't affect source (see issue #76)
       applyOperation(document,
-        { op: "add", path: this.path, value: valueToCopy }
+          { op: "add", path: this.path, value: _deepClone(valueToCopy) }
       );
       return {newDocument: document}
     },
@@ -264,8 +265,8 @@ module jsonpatch {
 
   /* The operations applicable to an array. Many are the same as for the object */
   var arrOps = {
-    add: function (arr, i, document) {
-      arr.splice(i, 0, _deepClone(this.value));
+    add: function (arr, i, document, copyByValue) {
+      arr.splice(i, 0, copyByValue ? _deepClone(this.value) : this.value);
       // this may be needed when using '-' in an array
       return {newDocument: document, index: i}
     },
@@ -273,9 +274,9 @@ module jsonpatch {
       var removedList = arr.splice(i, 1);
       return {newDocument: document, removed: removedList[0]};
     },
-    replace: function (arr, i, document) {
+    replace: function (arr, i, document, copyByValue) {
       var removed = arr[i];
-      arr[i] = _deepClone(this.value);
+      arr[i] = copyByValue ? _deepClone(this.value) : this.value;
       return {newDocument: document, removed};
     },
     move: objOps.move,
@@ -616,9 +617,10 @@ module jsonpatch {
    * @param operation The operation to apply
    * @param validateOperation `false` is without validation, `true` to use default jsonpatch's validation, or you can pass a `validateOperation` callback to be used for validation.
    * @param mutateDocument Whether to mutate the original document or clone it before applying
+   * @param copyByValue Whether to copy operation `value` properties by value or reference
    * @return `{newDocument, result}` after the operation
    */
-  export function applyOperation<T>(document: T, operation: Operation, validateOperation: boolean | Validator<T> = false, mutateDocument: boolean = true): OperationResult<T> {
+  export function applyOperation<T>(document: T, operation: Operation, validateOperation: boolean | Validator<T> = false, mutateDocument: boolean = true, copyByValue: boolean = false): OperationResult<T> {
     if (validateOperation) {
       if (typeof validateOperation == 'function') {
         validateOperation(operation, 0, document, operation.path);
@@ -712,7 +714,7 @@ module jsonpatch {
             if (validateOperation && operation.op === "add" && key > obj.length) {
               throw new JsonPatchError("The specified index MUST NOT be greater than the number of elements in the array", "OPERATION_VALUE_OUT_OF_BOUNDS", 0, operation.path, operation);
             }
-            returnValue = arrOps[operation.op].call(operation, obj, key, document); // Apply patch
+            returnValue = arrOps[operation.op].call(operation, obj, key, document, copyByValue); // Apply patch
             if (returnValue.test === false) {
               throw new JsonPatchError("Test operation failed", 'TEST_OPERATION_FAILED', 0, operation, document);
             }
@@ -724,7 +726,7 @@ module jsonpatch {
             key = unescapePathComponent(key);
           }
           if (t >= len) {
-            returnValue = objOps[operation.op].call(operation, obj, key, document); // Apply patch
+            returnValue = objOps[operation.op].call(operation, obj, key, document, copyByValue); // Apply patch
             if (returnValue.test === false) {
               throw new JsonPatchError("Test operation failed", 'TEST_OPERATION_FAILED', 0, operation, document);
             }
@@ -743,13 +745,14 @@ module jsonpatch {
    * @param document The document to patch
    * @param patch The patch to apply
    * @param validateOperation `false` is without validation, `true` to use default jsonpatch's validation, or you can pass a `validateOperation` callback to be used for validation.
+   * @param copyByValue Whether to copy operation `value` properties by value or reference
    * @return An array of `{newDocument, result}` after the patch
    */
-  export function applyPatch<T>(document: T, patch: Operation[], validateOperation?: boolean | Validator<T>): PatchResult<T> {
+  export function applyPatch<T>(document: T, patch: Operation[], validateOperation?: boolean | Validator<T>, copyByValue: boolean = false): PatchResult<T> {
     const results = new Array(patch.length) as PatchResult<T>;
     
     for (let i = 0, length = patch.length; i < length; i++) {
-      results[i] = applyOperation(document, patch[i], validateOperation);
+      results[i] = applyOperation(document, patch[i], validateOperation, true, copyByValue);
       document = results[i].newDocument; // in case root was replaced
     }
     results.newDocument = document;
@@ -764,7 +767,7 @@ module jsonpatch {
    * or just be undefined
    * @deprecated
    */
-  export function apply<T>(document: T, patch: Operation[], validateOperation?: boolean | Validator<T>): any[] {
+  export function apply<T>(document: T, patch: Operation[], validateOperation?: boolean | Validator<T>, copyByValue: boolean = false): any[] {
     console.warn('jsonpatch.apply is deprecated, please use `applyPatch` for applying patch sequences, or `applyOperation` to apply individual operations.');
     const results = new Array(patch.length);
 
@@ -793,7 +796,7 @@ module jsonpatch {
 
       }
       else {
-        results[i] = applyOperation(document, patch[i], validateOperation);
+        results[i] = applyOperation(document, patch[i], validateOperation, true, copyByValue);
         results[i] = results[i].removed || results[i].test;
       }
     }
@@ -935,7 +938,7 @@ module jsonpatch {
       }
       if (document) {
         document = JSON.parse(JSON.stringify(document)); //clone document so that we can safely try applying operations
-        applyPatch(document, sequence, externalValidator || true);
+        applyPatch(document, sequence, externalValidator || true, true);
       }
       else {
         externalValidator = externalValidator || validator;

--- a/src/json-patch.d.ts
+++ b/src/json-patch.d.ts
@@ -63,6 +63,13 @@ declare namespace jsonpatch {
     type TestPatch<T> = TestOperation<T>;
     type JsonPatchErrorName = 'SEQUENCE_NOT_AN_ARRAY' | 'OPERATION_NOT_AN_OBJECT' | 'OPERATION_OP_INVALID' | 'OPERATION_PATH_INVALID' | 'OPERATION_FROM_REQUIRED' | 'OPERATION_VALUE_REQUIRED' | 'OPERATION_VALUE_CANNOT_CONTAIN_UNDEFINED' | 'OPERATION_PATH_CANNOT_ADD' | 'OPERATION_PATH_UNRESOLVABLE' | 'OPERATION_FROM_UNRESOLVABLE' | 'OPERATION_PATH_ILLEGAL_ARRAY_INDEX' | 'OPERATION_VALUE_OUT_OF_BOUNDS' | 'TEST_OPERATION_FAILED';
     /**
+     * Deeply clone the object.
+     * https://jsperf.com/deep-copy-vs-json-stringify-json-parse/25 (recursiveDeepCopy)
+     * @param  {any} obj value to clone
+     * @return {any}       cloned obj
+     */
+    function deepClone(obj: any): any;
+    /**
     * Escapes a json pointer path
     * @param path The raw pointer
     * @return the Escaped path
@@ -86,26 +93,30 @@ declare namespace jsonpatch {
     /**
      * Apply a single JSON Patch Operation on a JSON document.
      * Returns the {newDocument, result} of the operation.
+     * It modifies the `document` object and `operation` - it gets the values by reference.
+     * If you would like to avoid touching your values, clone them:
+     * `jsonpatch.apply(document, jsonpatch.deepClone(operation))`.
      *
      * @param document The document to patch
      * @param operation The operation to apply
      * @param validateOperation `false` is without validation, `true` to use default jsonpatch's validation, or you can pass a `validateOperation` callback to be used for validation.
      * @param mutateDocument Whether to mutate the original document or clone it before applying
-     * @param copyByValue Whether to copy operation `value` properties by value or reference
      * @return `{newDocument, result}` after the operation
      */
-    function applyOperation<T>(document: T, operation: Operation, validateOperation?: boolean | Validator<T>, mutateDocument?: boolean, copyByValue?: boolean): OperationResult<T>;
+    function applyOperation<T>(document: T, operation: Operation, validateOperation?: boolean | Validator<T>, mutateDocument?: boolean): OperationResult<T>;
     /**
      * Apply a full JSON Patch array on a JSON document.
      * Returns the {newDocument, result} of the patch.
+     * It modifies the `document` object and `patch` - it gets the values by reference.
+     * If you would like to avoid touching your values, clone them:
+     * `jsonpatch.apply(document, jsonpatch.deepClone(patch))`.
      *
      * @param document The document to patch
      * @param patch The patch to apply
      * @param validateOperation `false` is without validation, `true` to use default jsonpatch's validation, or you can pass a `validateOperation` callback to be used for validation.
-     * @param copyByValue Whether to copy operation `value` properties by value or reference
      * @return An array of `{newDocument, result}` after the patch, with a `newDocument` property for accessing the final state with ease.
      */
-    function applyPatch<T>(document: T, patch: Operation[], validateOperation?: boolean | Validator<T>, copyByValue?: boolean): PatchResult<T>;
+    function applyPatch<T>(document: T, patch: Operation[], validateOperation?: boolean | Validator<T>): PatchResult<T>;
     /**
      * Apply a JSON Patch on a JSON document.
      * Returns an array of results of operations.
@@ -114,7 +125,7 @@ declare namespace jsonpatch {
      * or just be undefined
      * @deprecated
      */
-    function apply<T>(document: T, patch: Operation[], validateOperation?: boolean | Validator<T>, copyByValue?: boolean): any[];
+    function apply<T>(document: T, patch: Operation[], validateOperation?: boolean | Validator<T>): any[];
     /**
      * Apply a single JSON Patch Operation on a JSON document.
      * Returns the updated document.
@@ -128,9 +139,9 @@ declare namespace jsonpatch {
     class JsonPatchError extends Error {
         message: string;
         name: JsonPatchErrorName;
-        index?: number;
-        operation?: any;
-        tree?: any;
+        index: number;
+        operation: any;
+        tree: any;
         constructor(message: string, name: JsonPatchErrorName, index?: number, operation?: any, tree?: any);
     }
     /**

--- a/src/json-patch.d.ts
+++ b/src/json-patch.d.ts
@@ -91,9 +91,10 @@ declare namespace jsonpatch {
      * @param operation The operation to apply
      * @param validateOperation `false` is without validation, `true` to use default jsonpatch's validation, or you can pass a `validateOperation` callback to be used for validation.
      * @param mutateDocument Whether to mutate the original document or clone it before applying
+     * @param copyByValue Whether to copy operation `value` properties by value or reference
      * @return `{newDocument, result}` after the operation
      */
-    function applyOperation<T>(document: T, operation: Operation, validateOperation?: boolean | Validator<T>, mutateDocument?: boolean): OperationResult<T>;
+    function applyOperation<T>(document: T, operation: Operation, validateOperation?: boolean | Validator<T>, mutateDocument?: boolean, copyByValue?: boolean): OperationResult<T>;
     /**
      * Apply a full JSON Patch array on a JSON document.
      * Returns the {newDocument, result} of the patch.
@@ -101,9 +102,10 @@ declare namespace jsonpatch {
      * @param document The document to patch
      * @param patch The patch to apply
      * @param validateOperation `false` is without validation, `true` to use default jsonpatch's validation, or you can pass a `validateOperation` callback to be used for validation.
+     * @param copyByValue Whether to copy operation `value` properties by value or reference
      * @return An array of `{newDocument, result}` after the patch, with a `newDocument` property for accessing the final state with ease.
      */
-    function applyPatch<T>(document: T, patch: Operation[], validateOperation?: boolean | Validator<T>): PatchResult<T>;
+    function applyPatch<T>(document: T, patch: Operation[], validateOperation?: boolean | Validator<T>, copyByValue?: boolean): PatchResult<T>;
     /**
      * Apply a JSON Patch on a JSON document.
      * Returns an array of results of operations.
@@ -112,7 +114,7 @@ declare namespace jsonpatch {
      * or just be undefined
      * @deprecated
      */
-    function apply<T>(document: T, patch: Operation[], validateOperation?: boolean | Validator<T>): any[];
+    function apply<T>(document: T, patch: Operation[], validateOperation?: boolean | Validator<T>, copyByValue?: boolean): any[];
     /**
      * Apply a single JSON Patch Operation on a JSON document.
      * Returns the updated document.

--- a/src/json-patch.js
+++ b/src/json-patch.js
@@ -70,43 +70,6 @@ var jsonpatch;
                 return false;
         }
     }
-    
-    function _deepClone(value) {
-        // from here https://jsperf.com/deep-copy-vs-json-stringify-json-parse/25 (recursiveDeepCopy)
-        var clone;
-        var i;
-        if (typeof value !== 'object') {
-            return value;
-        }
-        if (!value) {
-            return value;
-        }
-        if ('[object Array]' === Object.prototype.toString.apply(value)) {
-            clone = [];
-            for (i = 0; i < value.length; i += 1) {
-                clone[i] = _deepClone(value[i]);
-            }
-            return clone;
-        }
-        clone = {};
-        for (i in value) {
-            if (value.hasOwnProperty(i)) {
-                clone[i] = _deepClone(value[i]);
-            }
-        }
-        return clone;
-    }
-    
-    function deepClone(obj) {
-        switch (typeof obj) {
-            case "object":
-                return JSON.parse(JSON.stringify(obj)); //Faster than ES5 clone - http://jsperf.com/deep-cloning-of-objects/5
-            case "undefined":
-                return null; //this is how JSON.stringify behaves for array items
-            default:
-                return obj; //no need to clone primitives
-        }
-    }
     /* We use a Javascript hash to store each
      function. Each hash entry (property) uses
      the operation identifiers specified in rfc6902.
@@ -115,8 +78,8 @@ var jsonpatch;
      */
     /* The operations applicable to an object */
     var objOps = {
-        add: function (obj, key, document, copyByValue) {
-            obj[key] = copyByValue ? _deepClone(this.value) : this.value;
+        add: function (obj, key, document) {
+            obj[key] = this.value;
             return { newDocument: document };
         },
         remove: function (obj, key, document) {
@@ -124,9 +87,9 @@ var jsonpatch;
             delete obj[key];
             return { newDocument: document, removed: removed };
         },
-        replace: function (obj, key, document, copyByValue) {
+        replace: function (obj, key, document) {
             var removed = obj[key];
-            obj[key] = copyByValue ? _deepClone(this.value) : this.value;
+            obj[key] = this.value;
             return { newDocument: document, removed: removed };
         },
         move: function (obj, key, document) {
@@ -143,8 +106,8 @@ var jsonpatch;
         },
         copy: function (obj, key, document) {
             var valueToCopy = getValueByPointer(document, this.from);
-            // enforce copy by value so further operations don't affect source (see issue #76)
-            applyOperation(document, { op: "add", path: this.path, value: _deepClone(valueToCopy) });
+            // enforce copy by value so further operations don't affect source (see issue #177)
+            applyOperation(document, { op: "add", path: this.path, value: deepClone(valueToCopy) });
             return { newDocument: document };
         },
         test: function (obj, key, document) {
@@ -157,8 +120,8 @@ var jsonpatch;
     };
     /* The operations applicable to an array. Many are the same as for the object */
     var arrOps = {
-        add: function (arr, i, document, copyByValue) {
-            arr.splice(i, 0, copyByValue ? _deepClone(this.value) : this.value);
+        add: function (arr, i, document) {
+            arr.splice(i, 0, this.value);
             // this may be needed when using '-' in an array
             return { newDocument: document, index: i };
         },
@@ -166,9 +129,9 @@ var jsonpatch;
             var removedList = arr.splice(i, 1);
             return { newDocument: document, removed: removedList[0] };
         },
-        replace: function (arr, i, document, copyByValue) {
+        replace: function (arr, i, document) {
             var removed = arr[i];
-            arr[i] = copyByValue ? _deepClone(this.value) : this.value;
+            arr[i] = this.value;
             return { newDocument: document, removed: removed };
         },
         move: objOps.move,
@@ -200,6 +163,23 @@ var jsonpatch;
         }
         return true;
     }
+    /**
+     * Deeply clone the object.
+     * https://jsperf.com/deep-copy-vs-json-stringify-json-parse/25 (recursiveDeepCopy)
+     * @param  {any} obj value to clone
+     * @return {any}       cloned obj
+     */
+    function deepClone(obj) {
+        switch (typeof obj) {
+            case "object":
+                return JSON.parse(JSON.stringify(obj)); //Faster than ES5 clone - http://jsperf.com/deep-cloning-of-objects/5
+            case "undefined":
+                return null; //this is how JSON.stringify behaves for array items
+            default:
+                return obj; //no need to clone primitives
+        }
+    }
+    jsonpatch.deepClone = deepClone;
     /**
     * Escapes a json pointer path
     * @param path The raw pointer
@@ -237,18 +217,19 @@ var jsonpatch;
     /**
      * Apply a single JSON Patch Operation on a JSON document.
      * Returns the {newDocument, result} of the operation.
+     * It modifies the `document` object and `operation` - it gets the values by reference.
+     * If you would like to avoid touching your values, clone them:
+     * `jsonpatch.apply(document, jsonpatch.deepClone(operation))`.
      *
      * @param document The document to patch
      * @param operation The operation to apply
      * @param validateOperation `false` is without validation, `true` to use default jsonpatch's validation, or you can pass a `validateOperation` callback to be used for validation.
      * @param mutateDocument Whether to mutate the original document or clone it before applying
-     * @param copyByValue Whether to copy operation `value` properties by value or reference
      * @return `{newDocument, result}` after the operation
      */
-    function applyOperation(document, operation, validateOperation, mutateDocument, copyByValue) {
+    function applyOperation(document, operation, validateOperation, mutateDocument) {
         if (validateOperation === void 0) { validateOperation = false; }
         if (mutateDocument === void 0) { mutateDocument = true; }
-        if (copyByValue === void 0) { copyByValue = false; }
         if (validateOperation) {
             if (typeof validateOperation == 'function') {
                 validateOperation(operation, 0, document, operation.path);
@@ -346,7 +327,7 @@ var jsonpatch;
                         if (validateOperation && operation.op === "add" && key > obj.length) {
                             throw new JsonPatchError("The specified index MUST NOT be greater than the number of elements in the array", "OPERATION_VALUE_OUT_OF_BOUNDS", 0, operation.path, operation);
                         }
-                        var returnValue = arrOps[operation.op].call(operation, obj, key, document, copyByValue); // Apply patch
+                        var returnValue = arrOps[operation.op].call(operation, obj, key, document); // Apply patch
                         if (returnValue.test === false) {
                             throw new JsonPatchError("Test operation failed", 'TEST_OPERATION_FAILED', 0, operation, document);
                         }
@@ -358,7 +339,7 @@ var jsonpatch;
                         key = unescapePathComponent(key);
                     }
                     if (t >= len) {
-                        var returnValue = objOps[operation.op].call(operation, obj, key, document, copyByValue); // Apply patch
+                        var returnValue = objOps[operation.op].call(operation, obj, key, document); // Apply patch
                         if (returnValue.test === false) {
                             throw new JsonPatchError("Test operation failed", 'TEST_OPERATION_FAILED', 0, operation, document);
                         }
@@ -373,18 +354,19 @@ var jsonpatch;
     /**
      * Apply a full JSON Patch array on a JSON document.
      * Returns the {newDocument, result} of the patch.
+     * It modifies the `document` object and `patch` - it gets the values by reference.
+     * If you would like to avoid touching your values, clone them:
+     * `jsonpatch.apply(document, jsonpatch.deepClone(patch))`.
      *
      * @param document The document to patch
      * @param patch The patch to apply
      * @param validateOperation `false` is without validation, `true` to use default jsonpatch's validation, or you can pass a `validateOperation` callback to be used for validation.
-     * @param copyByValue Whether to copy operation `value` properties by value or reference
      * @return An array of `{newDocument, result}` after the patch, with a `newDocument` property for accessing the final state with ease.
      */
-    function applyPatch(document, patch, validateOperation, copyByValue) {
-        if (copyByValue === void 0) { copyByValue = false; }
+    function applyPatch(document, patch, validateOperation) {
         var results = new Array(patch.length);
         for (var i = 0, length_1 = patch.length; i < length_1; i++) {
-            results[i] = applyOperation(document, patch[i], validateOperation, true, copyByValue);
+            results[i] = applyOperation(document, patch[i], validateOperation, true);
             document = results[i].newDocument; // in case root was replaced
         }
         results.newDocument = document;
@@ -399,8 +381,7 @@ var jsonpatch;
      * or just be undefined
      * @deprecated
      */
-    function apply(document, patch, validateOperation, copyByValue) {
-        if (copyByValue === void 0) { copyByValue = false; }
+    function apply(document, patch, validateOperation) {
         console.warn('jsonpatch.apply is deprecated, please use `applyPatch` for applying patch sequences, or `applyOperation` to apply individual operations.');
         var results = new Array(patch.length);
         /* this code might be overkill, but will be removed soon, it is to prevent the breaking change of root operations */
@@ -422,7 +403,7 @@ var jsonpatch;
                 Object.keys(value_1).forEach(function (key) { return document[key] = value_1[key]; });
             }
             else {
-                results[i] = applyOperation(document, patch[i], validateOperation, true, copyByValue);
+                results[i] = applyOperation(document, patch[i], validateOperation, true);
                 results[i] = results[i].removed || results[i].test;
             }
         };
@@ -563,8 +544,8 @@ var jsonpatch;
                 throw new JsonPatchError('Patch sequence must be an array', 'SEQUENCE_NOT_AN_ARRAY');
             }
             if (document) {
-                document = JSON.parse(JSON.stringify(document)); //clone document so that we can safely try applying operations
-                applyPatch(document, sequence, externalValidator || true, true);
+                //clone document so that we can safely try applying operations
+                applyPatch(deepClone(document), deepClone(sequence), externalValidator || true);
             }
             else {
                 externalValidator = externalValidator || validator;
@@ -590,6 +571,7 @@ if (typeof exports !== "undefined") {
     exports.applyOperation = jsonpatch.applyOperation;
     exports.applyReducer = jsonpatch.applyReducer;
     exports.getValueByPointer = jsonpatch.getValueByPointer;
+    exports.deepClone = jsonpatch.deepClone;
     exports.escapePathComponent = jsonpatch.escapePathComponent;
     exports.unescapePathComponent = jsonpatch.unescapePathComponent;
     exports.validate = jsonpatch.validate;

--- a/src/json-patch.js
+++ b/src/json-patch.js
@@ -70,6 +70,16 @@ var jsonpatch;
                 return false;
         }
     }
+    
+    function _deepClone(value) {
+        if (typeof value === 'object') {
+            return JSON.parse(JSON.stringify(value));
+        }
+        else {
+            return value;
+        }
+    }
+    
     function deepClone(obj) {
         switch (typeof obj) {
             case "object":
@@ -89,7 +99,7 @@ var jsonpatch;
     /* The operations applicable to an object */
     var objOps = {
         add: function (obj, key, document) {
-            obj[key] = this.value;
+            obj[key] = _deepClone(this.value);
             return { newDocument: document };
         },
         remove: function (obj, key, document) {
@@ -99,7 +109,7 @@ var jsonpatch;
         },
         replace: function (obj, key, document) {
             var removed = obj[key];
-            obj[key] = this.value;
+            obj[key] = _deepClone(this.value);
             return { newDocument: document, removed: removed };
         },
         move: function (obj, key, document) {
@@ -130,7 +140,7 @@ var jsonpatch;
     /* The operations applicable to an array. Many are the same as for the object */
     var arrOps = {
         add: function (arr, i, document) {
-            arr.splice(i, 0, this.value);
+            arr.splice(i, 0, _deepClone(this.value));
             // this may be needed when using '-' in an array
             return { newDocument: document, index: i };
         },
@@ -140,7 +150,7 @@ var jsonpatch;
         },
         replace: function (arr, i, document) {
             var removed = arr[i];
-            arr[i] = this.value;
+            arr[i] = _deepClone(this.value);
             return { newDocument: document, removed: removed };
         },
         move: objOps.move,

--- a/src/json-patch.js
+++ b/src/json-patch.js
@@ -115,8 +115,8 @@ var jsonpatch;
      */
     /* The operations applicable to an object */
     var objOps = {
-        add: function (obj, key, document) {
-            obj[key] = _deepClone(this.value);
+        add: function (obj, key, document, copyByValue) {
+            obj[key] = copyByValue ? _deepClone(this.value) : this.value;
             return { newDocument: document };
         },
         remove: function (obj, key, document) {
@@ -124,9 +124,9 @@ var jsonpatch;
             delete obj[key];
             return { newDocument: document, removed: removed };
         },
-        replace: function (obj, key, document) {
+        replace: function (obj, key, document, copyByValue) {
             var removed = obj[key];
-            obj[key] = _deepClone(this.value);
+            obj[key] = copyByValue ? _deepClone(this.value) : this.value;
             return { newDocument: document, removed: removed };
         },
         move: function (obj, key, document) {
@@ -143,7 +143,8 @@ var jsonpatch;
         },
         copy: function (obj, key, document) {
             var valueToCopy = getValueByPointer(document, this.from);
-            applyOperation(document, { op: "add", path: this.path, value: valueToCopy });
+            // enforce copy by value so further operations don't affect source (see issue #76)
+            applyOperation(document, { op: "add", path: this.path, value: _deepClone(valueToCopy) });
             return { newDocument: document };
         },
         test: function (obj, key, document) {
@@ -156,8 +157,8 @@ var jsonpatch;
     };
     /* The operations applicable to an array. Many are the same as for the object */
     var arrOps = {
-        add: function (arr, i, document) {
-            arr.splice(i, 0, _deepClone(this.value));
+        add: function (arr, i, document, copyByValue) {
+            arr.splice(i, 0, copyByValue ? _deepClone(this.value) : this.value);
             // this may be needed when using '-' in an array
             return { newDocument: document, index: i };
         },
@@ -165,9 +166,9 @@ var jsonpatch;
             var removedList = arr.splice(i, 1);
             return { newDocument: document, removed: removedList[0] };
         },
-        replace: function (arr, i, document) {
+        replace: function (arr, i, document, copyByValue) {
             var removed = arr[i];
-            arr[i] = _deepClone(this.value);
+            arr[i] = copyByValue ? _deepClone(this.value) : this.value;
             return { newDocument: document, removed: removed };
         },
         move: objOps.move,
@@ -241,11 +242,13 @@ var jsonpatch;
      * @param operation The operation to apply
      * @param validateOperation `false` is without validation, `true` to use default jsonpatch's validation, or you can pass a `validateOperation` callback to be used for validation.
      * @param mutateDocument Whether to mutate the original document or clone it before applying
+     * @param copyByValue Whether to copy operation `value` properties by value or reference
      * @return `{newDocument, result}` after the operation
      */
-    function applyOperation(document, operation, validateOperation, mutateDocument) {
+    function applyOperation(document, operation, validateOperation, mutateDocument, copyByValue) {
         if (validateOperation === void 0) { validateOperation = false; }
         if (mutateDocument === void 0) { mutateDocument = true; }
+        if (copyByValue === void 0) { copyByValue = false; }
         if (validateOperation) {
             if (typeof validateOperation == 'function') {
                 validateOperation(operation, 0, document, operation.path);
@@ -343,7 +346,7 @@ var jsonpatch;
                         if (validateOperation && operation.op === "add" && key > obj.length) {
                             throw new JsonPatchError("The specified index MUST NOT be greater than the number of elements in the array", "OPERATION_VALUE_OUT_OF_BOUNDS", 0, operation.path, operation);
                         }
-                        var returnValue = arrOps[operation.op].call(operation, obj, key, document); // Apply patch
+                        var returnValue = arrOps[operation.op].call(operation, obj, key, document, copyByValue); // Apply patch
                         if (returnValue.test === false) {
                             throw new JsonPatchError("Test operation failed", 'TEST_OPERATION_FAILED', 0, operation, document);
                         }
@@ -355,7 +358,7 @@ var jsonpatch;
                         key = unescapePathComponent(key);
                     }
                     if (t >= len) {
-                        var returnValue = objOps[operation.op].call(operation, obj, key, document); // Apply patch
+                        var returnValue = objOps[operation.op].call(operation, obj, key, document, copyByValue); // Apply patch
                         if (returnValue.test === false) {
                             throw new JsonPatchError("Test operation failed", 'TEST_OPERATION_FAILED', 0, operation, document);
                         }
@@ -374,12 +377,14 @@ var jsonpatch;
      * @param document The document to patch
      * @param patch The patch to apply
      * @param validateOperation `false` is without validation, `true` to use default jsonpatch's validation, or you can pass a `validateOperation` callback to be used for validation.
+     * @param copyByValue Whether to copy operation `value` properties by value or reference
      * @return An array of `{newDocument, result}` after the patch, with a `newDocument` property for accessing the final state with ease.
      */
-    function applyPatch(document, patch, validateOperation) {
+    function applyPatch(document, patch, validateOperation, copyByValue) {
+        if (copyByValue === void 0) { copyByValue = false; }
         var results = new Array(patch.length);
         for (var i = 0, length_1 = patch.length; i < length_1; i++) {
-            results[i] = applyOperation(document, patch[i], validateOperation);
+            results[i] = applyOperation(document, patch[i], validateOperation, true, copyByValue);
             document = results[i].newDocument; // in case root was replaced
         }
         results.newDocument = document;
@@ -394,7 +399,8 @@ var jsonpatch;
      * or just be undefined
      * @deprecated
      */
-    function apply(document, patch, validateOperation) {
+    function apply(document, patch, validateOperation, copyByValue) {
+        if (copyByValue === void 0) { copyByValue = false; }
         console.warn('jsonpatch.apply is deprecated, please use `applyPatch` for applying patch sequences, or `applyOperation` to apply individual operations.');
         var results = new Array(patch.length);
         /* this code might be overkill, but will be removed soon, it is to prevent the breaking change of root operations */
@@ -416,7 +422,7 @@ var jsonpatch;
                 Object.keys(value_1).forEach(function (key) { return document[key] = value_1[key]; });
             }
             else {
-                results[i] = applyOperation(document, patch[i], validateOperation);
+                results[i] = applyOperation(document, patch[i], validateOperation, true, copyByValue);
                 results[i] = results[i].removed || results[i].test;
             }
         };
@@ -558,7 +564,7 @@ var jsonpatch;
             }
             if (document) {
                 document = JSON.parse(JSON.stringify(document)); //clone document so that we can safely try applying operations
-                applyPatch(document, sequence, externalValidator || true);
+                applyPatch(document, sequence, externalValidator || true, true);
             }
             else {
                 externalValidator = externalValidator || validator;

--- a/src/json-patch.js
+++ b/src/json-patch.js
@@ -72,12 +72,29 @@ var jsonpatch;
     }
     
     function _deepClone(value) {
-        if (typeof value === 'object') {
-            return JSON.parse(JSON.stringify(value));
-        }
-        else {
+        // from here https://jsperf.com/deep-copy-vs-json-stringify-json-parse/25 (recursiveDeepCopy)
+        var clone;
+        var i;
+        if (typeof value !== 'object') {
             return value;
         }
+        if (!value) {
+            return value;
+        }
+        if ('[object Array]' === Object.prototype.toString.apply(value)) {
+            clone = [];
+            for (i = 0; i < value.length; i += 1) {
+                clone[i] = _deepClone(value[i]);
+            }
+            return clone;
+        }
+        clone = {};
+        for (i in value) {
+            if (value.hasOwnProperty(i)) {
+                clone[i] = _deepClone(value[i]);
+            }
+        }
+        return clone;
     }
     
     function deepClone(obj) {

--- a/src/json-patch.ts
+++ b/src/json-patch.ts
@@ -162,11 +162,32 @@ namespace jsonpatch {
   }
   
   function _deepClone(value) {
-    if (typeof value === 'object') {
-      return JSON.parse(JSON.stringify(value));
-    } else {
+    // from here https://jsperf.com/deep-copy-vs-json-stringify-json-parse/25 (recursiveDeepCopy)
+    var clone;
+    var i;
+
+    if (typeof value !== 'object') {
       return value;
     }
+    if (!value) {
+      return value;
+    }
+
+    if ('[object Array]' === Object.prototype.toString.apply(value)) {
+      clone = [];
+      for (i = 0; i < value.length; i += 1) {
+        clone[i] = _deepClone(value[i]);
+      }
+      return clone;
+    }
+
+    clone = {};
+    for (i in value) {
+      if (value.hasOwnProperty(i)) {
+        clone[i] = _deepClone(value[i]);
+      }
+    }
+    return clone;
   }
   
   function deepClone(obj: any) {

--- a/src/json-patch.ts
+++ b/src/json-patch.ts
@@ -160,6 +160,15 @@ namespace jsonpatch {
         return false;
     }
   }
+  
+  function _deepClone(value) {
+    if (typeof value === 'object') {
+      return JSON.parse(JSON.stringify(value));
+    } else {
+      return value;
+    }
+  }
+  
   function deepClone(obj: any) {
     switch (typeof obj) {
       case "object":
@@ -172,6 +181,7 @@ namespace jsonpatch {
         return obj; //no need to clone primitives
     }
   }
+
   /* We use a Javascript hash to store each
    function. Each hash entry (property) uses
    the operation identifiers specified in rfc6902.
@@ -182,7 +192,7 @@ namespace jsonpatch {
   /* The operations applicable to an object */
   const objOps = {
     add: function (obj, key, document) {
-      obj[key] = this.value;
+      obj[key] = _deepClone(this.value);
       return {newDocument: document};
     },
     remove: function (obj, key, document) {
@@ -192,7 +202,7 @@ namespace jsonpatch {
     },
     replace: function (obj, key, document) {
       var removed = obj[key];
-      obj[key] = this.value;
+      obj[key] = _deepClone(this.value);
       return {newDocument: document, removed};
     },
     move: function (obj, key, document) {
@@ -235,7 +245,7 @@ namespace jsonpatch {
   /* The operations applicable to an array. Many are the same as for the object */
   var arrOps = {
     add: function (arr, i, document) {
-      arr.splice(i, 0, this.value);
+      arr.splice(i, 0, _deepClone(this.value));
       // this may be needed when using '-' in an array
       return {newDocument: document, index: i}
     },
@@ -245,7 +255,7 @@ namespace jsonpatch {
     },
     replace: function (arr, i, document) {
       var removed = arr[i];
-      arr[i] = this.value;
+      arr[i] = _deepClone(this.value);
       return {newDocument: document, removed};
     },
     move: objOps.move,

--- a/test/spec/coreSpec.js
+++ b/test/spec/coreSpec.js
@@ -659,7 +659,7 @@ describe('core - using applyOperation', function() {
         }
       }).newDocument
     ).toEqual(obj);
-    
+
     expect(() =>
       jsonpatch.applyOperation(obj, {
         op: 'test',
@@ -1419,7 +1419,7 @@ describe('core', function() {
     });
   });
 
-  it('should apply copy without side effects', function() {
+  it('should apply copy, without leaving cross-reference between nodes', function() {
     var obj = {};
     var patchset = [
       {op: 'add', path: '/foo', value: []},
@@ -1436,23 +1436,15 @@ describe('core', function() {
     });
   });
 
-  it('should apply a patchset twice without side effects with copyByValue flag enabled', function () {
+  it('should use value object as a reference', function () {
     var obj1 = {};
-    var obj2 = {};
-    var patchset = [
-      {op: 'add', path: '/foo', value: []},
-      {op: 'add', path: '/foo/-', value: 1},
+    var patch = [
+      {op: 'add', path: '/foo', value: []}
     ];
 
-    jsonpatch.apply(obj1, patchset, false, true);
-    jsonpatch.apply(obj2, patchset, false, true);
+    jsonpatch.apply(obj1, patch, false);
 
-    expect(obj1).toEqual({
-      "foo": [1],
-    });
-    expect(obj2).toEqual({
-      "foo": [1],
-    });
+    expect(obj1.foo).toBe(patch[0].value);
   });
 
   describe('returning removed elements >', function() {
@@ -1801,12 +1793,11 @@ describe('undefined - JS to JSON projection / JSON to JS extension', function() 
       });
     });
 
-    it('copy of `undefined`', function() {
+    it('copy of `undefined` as `null` (like `JSON.stringify` does)', function() {
       obj = {
         foo: undefined,
         baz: 'defined'
       };
-
       jsonpatch.applyPatch(obj, [
         {
           op: 'copy',
@@ -1817,7 +1808,7 @@ describe('undefined - JS to JSON projection / JSON to JS extension', function() 
       expect(obj).toEqual({
         foo: undefined,
         baz: 'defined',
-        bar: undefined
+        bar: null
       });
 
       jsonpatch.applyPatch(obj, [
@@ -1829,8 +1820,8 @@ describe('undefined - JS to JSON projection / JSON to JS extension', function() 
       ]);
       expect(obj).toEqual({
         foo: undefined,
-        baz: undefined,
-        bar: undefined
+        baz: null,
+        bar: null
       });
     });
   });

--- a/test/spec/coreSpec.js
+++ b/test/spec/coreSpec.js
@@ -1436,6 +1436,25 @@ describe('core', function() {
     });
   });
 
+  it('should apply a patchset twice without side effects', function () {
+    var obj1 = {};
+    var obj2 = {};
+    var patchset = [
+      {op: 'add', path: '/foo', value: []},
+      {op: 'add', path: '/foo/-', value: 1},
+    ];
+
+    jsonpatch.apply(obj1, patchset);
+    jsonpatch.apply(obj2, patchset);
+
+    expect(obj1).toEqual({
+      "foo": [1],
+    });
+    expect(obj2).toEqual({
+      "foo": [1],
+    });
+  });
+
   describe('returning removed elements >', function() {
     var obj;
     beforeEach(function() {

--- a/test/spec/coreSpec.js
+++ b/test/spec/coreSpec.js
@@ -1419,6 +1419,23 @@ describe('core', function() {
     });
   });
 
+  it('should apply copy without side effects', function() {
+    var obj = {};
+    var patchset = [
+      {op: 'add', path: '/foo', value: []},
+      {op: 'add', path: '/foo/-', value: 1},
+      {op: 'copy', from: '/foo', path: '/bar'},
+      {op: 'add', path: '/bar/-', value: 2}
+    ];
+
+    jsonpatch.apply(obj, patchset);
+
+    expect(obj).toEqual({
+      "foo": [1],
+      "bar": [1, 2],
+    });
+  });
+
   describe('returning removed elements >', function() {
     var obj;
     beforeEach(function() {

--- a/test/spec/coreSpec.js
+++ b/test/spec/coreSpec.js
@@ -1436,7 +1436,7 @@ describe('core', function() {
     });
   });
 
-  it('should apply a patchset twice without side effects', function () {
+  it('should apply a patchset twice without side effects with copyByValue flag enabled', function () {
     var obj1 = {};
     var obj2 = {};
     var patchset = [
@@ -1444,8 +1444,8 @@ describe('core', function() {
       {op: 'add', path: '/foo/-', value: 1},
     ];
 
-    jsonpatch.apply(obj1, patchset);
-    jsonpatch.apply(obj2, patchset);
+    jsonpatch.apply(obj1, patchset, false, true);
+    jsonpatch.apply(obj2, patchset, false, true);
 
     expect(obj1).toEqual({
       "foo": [1],

--- a/test/spec/validateSpec.js
+++ b/test/spec/validateSpec.js
@@ -66,7 +66,7 @@ describe('validate', function() {
     expect(error.name).toBe('SEQUENCE_NOT_AN_ARRAY');
   });
 
-  it('should return an error that contains the patch and the patched object', function() {
+  it('should return an error that contains the cloned patch and the patched object', function() {
     var tree = {
       name: 'Elvis',
       cars: []
@@ -79,7 +79,7 @@ describe('validate', function() {
     ];
     var error = jsonpatch.validate(sequence, tree);
     expect(error instanceof jsonpatch.JsonPatchError).toBe(true);
-    expect(error.operation).toBe(sequence[0]);
+    expect(JSON.stringify(error.operation)).toBe(JSON.stringify(sequence[0]));
     expect(JSON.stringify(error.tree)).toBe(JSON.stringify(tree));
     expect(error.name).toBe('OPERATION_PATH_UNRESOLVABLE');
   });

--- a/test/spec/validateSpec.js
+++ b/test/spec/validateSpec.js
@@ -574,4 +574,30 @@ describe('validate', function() {
 
     expect(ex.name).toBe('OPERATION_VALUE_REQUIRED');
   });
+
+  it('should not modify patch value of type array (issue #76)', function () {
+    var patches = [
+      {op: 'add', path: '/foo', value: []},
+      {op: 'add', path: '/foo/-', value: 1}
+    ];
+    jsonpatch.validate(patches, {});
+
+    expect(patches).toEqual([
+      {op: 'add', path: '/foo', value: []},
+      {op: 'add', path: '/foo/-', value: 1}
+    ]);
+  });
+
+  it('should not modify patch value of type object (issue #76)', function () {
+    var patches = [
+      {op: 'add', path: '/foo', value: {}},
+      {op: 'add', path: '/foo/bar', value: 1}
+    ];
+    jsonpatch.validate(patches, {});
+
+    expect(patches).toEqual([
+      {op: 'add', path: '/foo', value: {}},
+      {op: 'add', path: '/foo/bar', value: 1}
+    ]);
+  });
 });


### PR DESCRIPTION
Evolution of https://github.com/Starcounter-Jack/JSON-Patch/pull/134 according to https://github.com/Starcounter-Jack/JSON-Patch/pull/134#pullrequestreview-40814902

Now, we:
 - Clone before copy (fixes https://github.com/Starcounter-Jack/JSON-Patch/issues/177),
 - Clone before validate (fixes #76),
 - Export `deepClone`,
 - Do not clone before any other operation,
 - Advise in docs to use `deepClone` in author's code to prevent adding value by reference,


I have left deepClone as it was, as we need implementation that respects `toJSON`, we can change it by separate PR, maybe for external npm module.

Breaking changes:
 - `copy` clones - naturally,
 - `copy` changes `undefined` to `null` - consequence of cloninig,
 - Errors returns clone of a patch, not a reference to original patch

Performance remains untouched, except `copy`
<details>
  <summary>Benchmark</summary>
<table>
<tr>
<th>1.2.0</th><th>after this PR</th>
</tr><tr>
<td><pre><code>jsonpatch-core
------------------
add operation
 Ops/sec: 2085857 ±1.61% Ran 111947 times in 0.054 seconds.
remove operation
 Ops/sec: 1121161 ±1.02% Ran 60083 times in 0.054 seconds.
replace operation
 Ops/sec: 2095337 ±1.54% Ran 114248 times in 0.055 seconds.
move operation
 Ops/sec: 200421 ±0.90% Ran 13297 times in 0.066 seconds.
copy operation
 Ops/sec: 194878 ±1.32% Ran 18987 times in 0.097 seconds.
test operation
 Ops/sec: 567632 ±0.88% Ran 29778 times in 0.052 seconds.
------------------
jsonpatch-duplex
------------------
add operation
 Ops/sec: 2135435 ±0.92% Ran 113462 times in 0.053 seconds.
remove operation
 Ops/sec: 1052344 ±0.91% Ran 56597 times in 0.054 seconds.
replace operation
 Ops/sec: 2147577 ±1.08% Ran 113836 times in 0.053 seconds.
move operation
 Ops/sec: 197426 ±2.04% Ran 12427 times in 0.063 seconds.
copy operation
 Ops/sec: 200374 ±1.50% Ran 17172 times in 0.086 seconds.
test operation
 Ops/sec: 535658 ±1.47% Ran 28399 times in 0.053 seconds.
------------------
generate operation
 Ops/sec: 423345 ±1.37% Ran 24261 times in 0.057 seconds.
generate operation and re-apply
 Ops/sec: 311452 ±1.36% Ran 17325 times in 0.056 seconds.
compare operation
 Ops/sec: 195977 ±0.54% Ran 10139 times in 0.052 seconds.
compare operation same but deep objects
 Ops/sec: 96098805 ±0.66% Ran 4970197 times in 0.052 seconds.
</code></pre></td>




<td><pre><code>jsonpatch-core
------------------
add operation
 Ops/sec: 2204575 ±0.97% Ran 115374 times in 0.052 seconds.
remove operation
 Ops/sec: 1053161 ±0.92% Ran 56157 times in 0.053 seconds.
replace operation
 Ops/sec: 2197116 ±1.21% Ran 116333 times in 0.053 seconds.
move operation
 Ops/sec: 207185 ±1.14% Ran 11747 times in 0.057 seconds.
copy operation
 Ops/sec: 136267 ±3.42% Ran 8575 times in 0.063 seconds.
test operation
 Ops/sec: 542997 ±3.23% Ran 30413 times in 0.056 seconds.
------------------
jsonpatch-duplex
------------------
add operation
 Ops/sec: 2238806 ±1.23% Ran 118332 times in 0.053 seconds.
remove operation
 Ops/sec: 1184853 ±0.90% Ran 62865 times in 0.053 seconds.
replace operation
 Ops/sec: 2191127 ±1.37% Ran 116504 times in 0.053 seconds.
move operation
 Ops/sec: 201986 ±1.19% Ran 12366 times in 0.061 seconds.
copy operation
 Ops/sec: 145574 ±0.84% Ran 7676 times in 0.053 seconds.
test operation
 Ops/sec: 564743 ±2.00% Ran 30439 times in 0.054 seconds.
------------------
generate operation
 Ops/sec: 420888 ±1.32% Ran 23777 times in 0.056 seconds.
generate operation and re-apply
 Ops/sec: 309766 ±1.43% Ran 17370 times in 0.056 seconds.
compare operation
 Ops/sec: 196895 ±0.63% Ran 10315 times in 0.052 seconds.
compare operation same but deep objects
 Ops/sec: 96919177 ±0.57% Ran 5003082 times in 0.052 seconds.
</code></pre></td>
</tr></table>

</details>

@felixfbecker, @barangs WDYT?