### PR TITLE
Ignore tsconfig.json when publishing to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,6 +5,7 @@ test/
 .travis.yml
 !*.d.ts
 src/*
+tsconfig.json
 
 # Mac OS X
 .DS_Store


### PR DESCRIPTION
This file is making my VisualStudio Code complain that there is no source files matching the pattern in this config file (which there isn't since they are already ignored).

> file: 'file:///my-app-dir/node_modules/fast-json-patch/tsconfig.json'
severity: 'Error'
message: 'No inputs were found in config file '/my-app-dir/node_modules/fast-json-patch/tsconfig.json'. Specified 'include' paths were '["src/**/*.ts"]' and 'exclude' paths were '["lib/"]'.'
at: '1,1'
source: 'ts'