### PR TITLE
fix(#78): adding an element to an array use the path `foo/-` 

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "bench-duplex": "node test/spec/coreBenchmark.js DUPLEX=yes && node test/spec/duplexBenchmark.js"
   },
   "dependencies": {
-    "deep-equal": "^1.0.1"
+    "deep-equal": "^1.0.1",
+    "is-number": "^7.0.0"
   }
 }

--- a/src/duplex.ts
+++ b/src/duplex.ts
@@ -7,6 +7,7 @@ declare var require: any;
 
 const equalsOptions = { strict: true };
 const _equals = require('deep-equal');
+const isNumber = require('is-number');
 const areEquals = (a: any, b: any): boolean => {
   return _equals(a, b, equalsOptions)
 }
@@ -230,7 +231,8 @@ function _generate(mirror, obj, patches, path) {
   for (var t = 0; t < newKeys.length; t++) {
     var key = newKeys[t];
     if (!hasOwnProperty(mirror, key) && obj[key] !== undefined) {
-      patches.push({ op: "add", path: path + "/" + escapePathComponent(key), value: _deepClone(obj[key]) });
+      var pathSuffix = isNumber(key) ? "-" : escapePathComponent(key);
+      patches.push({ op: "add", path: path + "/" + pathSuffix, value: _deepClone(obj[key]) });
     }
   }
 }

--- a/test/spec/duplexSpec.js
+++ b/test/spec/duplexSpec.js
@@ -327,7 +327,7 @@ describe('duplex', function() {
       expect(patches).toReallyEqual([
         {
           op: 'add',
-          path: '/1',
+          path: '/-',
           value: 2
         }
       ]);
@@ -373,7 +373,7 @@ describe('duplex', function() {
       expect(patches).toReallyEqual([
         {
           op: 'add',
-          path: '/1',
+          path: '/-',
           value: {
             id: 2,
             name: 'Jerry'


### PR DESCRIPTION
See the issue #78 for discussion

I'm not sure how to approach this PR...
I had to change the tests, but both the old and new behaviours in the tests suite are RFC compliant as far as I know. 