### PR TITLE
Replace deep-equal with fast-deep-equal

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,6 @@
     "bench-duplex": "node test/spec/coreBenchmark.js DUPLEX=yes && node test/spec/duplexBenchmark.js"
   },
   "dependencies": {
-    "deep-equal": "^1.0.1"
+    "fast-deep-equal": "^2.0.1"
   }
 }

--- a/src/core.ts
+++ b/src/core.ts
@@ -5,10 +5,7 @@
  */
 declare var require: any;
 
-const _equals = require('fast-deep-equal');
-const areEquals = (a: any, b: any): boolean => {
-  return _equals(a, b)
-}
+const areEquals = require('fast-deep-equal');
 import { PatchError, _deepClone, isInteger, unescapePathComponent, hasUndefined } from './helpers';
 
 export const JsonPatchError = PatchError;

--- a/src/core.ts
+++ b/src/core.ts
@@ -5,10 +5,9 @@
  */
 declare var require: any;
 
-const equalsOptions = { strict: true };
-const _equals = require('deep-equal');
+const _equals = require('fast-deep-equal');
 const areEquals = (a: any, b: any): boolean => {
-  return _equals(a, b, equalsOptions)
+  return _equals(a, b)
 }
 import { PatchError, _deepClone, isInteger, unescapePathComponent, hasUndefined } from './helpers';
 


### PR DESCRIPTION
hello/
thank you for `fast-deep-equal`

I'm working on a [secure build system](https://github.com/metamask/sesify) to help prevent browserify apps from getting [hacked by evil dependencies](https://www.theregister.co.uk/2018/11/26/npm_repo_bitcoin_stealer/). Its based on https://github.com/Agoric/SES

Unfortunately `deep-equal` [does not work in SES](https://github.com/substack/node-deep-equal/issues/62)

I tried replacing it with `fast-deep-equal` and all the tests pass just fine.
Performance characteristics seem to be different, some fast and some slower.

benchmarks summary (percent change in ops/sec)
most notable:
```js
  'core test operation': '-8.53',
  'duplex copy operation': '10.59',
  'compare operation': '-8.47',
```
all:
```js
{ 'core add operation': '2.45',
  'core remove operation': '2.75',
  'core replace operation': '0.19',
  'core move operation': '-1.19',
  'core copy operation': '-3.38',
  'core test operation': '-8.53',
  'duplex add operation': '-0.95',
  'duplex remove operation': '-1.87',
  'duplex replace operation': '1.51',
  'duplex move operation': '-3.28',
  'duplex copy operation': '10.59',
  'duplex test operation': '0.13',
  'generate operation': '3.04',
  'generate operation and re-apply': '2.86',
  'compare operation': '-8.47',
  'compare operation same but deep objects': '2.38' }
```

benchmark diffs are as follows:
```diff
--- deep-equal.bench	2019-06-15 23:14:49.252265800 +0800
+++ fast-deep-equal.bench	2019-06-15 23:23:24.643633910 +0800
@@ -12,17 +12,17 @@
 Benchmark results:
 ------------------
 add operation
- Ops/sec: 6709567 ±2.34% Ran 365627 times in 0.054 seconds.
+ Ops/sec: 6873879 ±2.22% Ran 365369 times in 0.053 seconds.
 remove operation
- Ops/sec: 4755220 ±0.40% Ran 243615 times in 0.051 seconds.
+ Ops/sec: 4886104 ±0.52% Ran 253930 times in 0.052 seconds.
 replace operation
- Ops/sec: 6029168 ±2.41% Ran 317315 times in 0.053 seconds.
+ Ops/sec: 6040673 ±3.68% Ran 323589 times in 0.054 seconds.
 move operation
- Ops/sec: 379857 ±0.47% Ran 20875 times in 0.055 seconds.
+ Ops/sec: 375343 ±0.65% Ran 21884 times in 0.058 seconds.
 copy operation
- Ops/sec: 275935 ±8.43% Ran 20989 times in 0.076 seconds.
+ Ops/sec: 266610 ±11.76% Ran 22533 times in 0.085 seconds.
 test operation
- Ops/sec: 1909909 ±0.41% Ran 97696 times in 0.051 seconds.
+ Ops/sec: 1747059 ±0.53% Ran 90128 times in 0.052 seconds.
 ===================
 
 > fast-json-patch@2.1.0 bench-duplex /home/xyz/Development/JSON-Patch
@@ -34,17 +34,17 @@
 Benchmark results:
 ------------------
 add operation
- Ops/sec: 6789537 ±2.40% Ran 365797 times in 0.054 seconds.
+ Ops/sec: 6725306 ±2.27% Ran 355512 times in 0.053 seconds.
 remove operation
- Ops/sec: 4840151 ±0.37% Ran 249984 times in 0.052 seconds.
+ Ops/sec: 4749784 ±0.30% Ran 244786 times in 0.052 seconds.
 replace operation
- Ops/sec: 6036406 ±2.53% Ran 323974 times in 0.054 seconds.
+ Ops/sec: 6127607 ±1.79% Ran 323148 times in 0.053 seconds.
 move operation
- Ops/sec: 383722 ±0.47% Ran 20882 times in 0.054 seconds.
+ Ops/sec: 371117 ±0.83% Ran 22077 times in 0.059 seconds.
 copy operation
- Ops/sec: 253336 ±14.43% Ran 23206 times in 0.092 seconds.
+ Ops/sec: 280166 ±8.25% Ran 21155 times in 0.076 seconds.
 test operation
- Ops/sec: 1910137 ±0.35% Ran 97869 times in 0.051 seconds.
+ Ops/sec: 1912604 ±0.39% Ran 99469 times in 0.052 seconds.
 ===================
 
 
@@ -52,11 +52,11 @@
 Benchmark results:
 ------------------
 generate operation
- Ops/sec: 1775703 ±0.54% Ran 91838 times in 0.052 seconds.
+ Ops/sec: 1829731 ±0.59% Ran 94599 times in 0.052 seconds.
 generate operation and re-apply
- Ops/sec: 1579103 ±0.31% Ran 81554 times in 0.052 seconds.
+ Ops/sec: 1624296 ±0.40% Ran 83712 times in 0.052 seconds.
 compare operation
- Ops/sec: 489554 ±0.41% Ran 25188 times in 0.051 seconds.
+ Ops/sec: 448095 ±0.47% Ran 23280 times in 0.052 seconds.
 compare operation same but deep objects
- Ops/sec: 143639196 ±0.39% Ran 7454684 times in 0.052 seconds.
+ Ops/sec: 147050873 ±0.29% Ran 7603183 times in 0.052 seconds.
 ===================
```