### PR TITLE
TravisCI is not actually running all of your tests. This PR fixes the broken test script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "test-webpack-import": "webpack --env.NODE_ENV=test && jasmine test/spec/webpack/importSpec.build.js",
     "test-typings": "tsc test/spec/typings/typingsSpec.ts",
     "test-duplex": "node --experimental-modules jasmine-run.mjs test/**/*[sS]pec.mjs",
-    "test-core": "node --experimental-modules jasmine-run.mjs test/spec/jsonPatchTestsSpec.mjs test/spec/coreSpec.mjs test/spec/validateSpec.mjs",
+    "test-core": "node --experimental-modules jasmine-run.mjs 'test/spec/{jsonPatchTestsSpec,coreSpec,validateSpec}.mjs'",
     "bench": "npm run bench-core && npm run bench-duplex",
     "bench-core": "node test/spec/coreBenchmark.js",
     "bench-duplex": "node test/spec/coreBenchmark.js && node test/spec/duplexBenchmark.js"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/52180844/74503473-d64a8600-4ea5-11ea-9d82-f672e42e1979.png)

I found a few edge cases that aren't tested in this library, so I updated the validation tests (can send a PR later if I ever get around to fixing the code). Unfortunately I ran `npm run test` more times than I care to admit before realizing that the test script **isn't actually running all of the tests**.

The script only looks at the first command-line argument, but the script `test-core` passes in **3** command-line arguments! So, this PR changes that to a single glob pattern, ensuring that all tests run via `npm run test`. Note that the browser tests don't suffer from this problem.