### PR TITLE
Fix #250 - Object/Array substitution should generate just a replace op

### DIFF
--- a/src/duplex.ts
+++ b/src/duplex.ts
@@ -163,7 +163,7 @@ function _generate(mirror, obj, patches, path, invertible) {
     if (hasOwnProperty(obj, key) && !(obj[key] === undefined && oldVal !== undefined && Array.isArray(obj) === false)) {
       var newVal = obj[key];
 
-      if (typeof oldVal == "object" && oldVal != null && typeof newVal == "object" && newVal != null) {
+      if (typeof oldVal == "object" && oldVal != null && typeof newVal == "object" && newVal != null && (Array.isArray(oldVal) === Array.isArray(newVal))) {
         _generate(oldVal, newVal, patches, path + "/" + escapePathComponent(key), invertible);
       }
       else {

--- a/test/spec/duplexSpec.mjs
+++ b/test/spec/duplexSpec.mjs
@@ -444,6 +444,56 @@ describe('duplex', function() {
       ]);
     });
 
+    it('should not mutate the document (object to array substitution)', function() {
+      const obj = {
+        data: {foo: 'bar'}
+      };
+
+      const observer = jsonpatch.observe(obj);
+      obj.data = [1, 2];
+
+      const obj2 = jsonpatch.deepClone(obj);
+
+      jsonpatch.generate(observer);
+      expect(obj2).toReallyEqual(obj);
+    });
+
+    it('should generate replace (object to array substitution)', function() {
+      const obj = {
+        data: {foo: 'bar'}
+      };
+
+      const observer = jsonpatch.observe(obj);
+      obj.data = [1, 2]
+
+      const patches = jsonpatch.generate(observer);
+
+      const obj2 = {
+        data: {foo: 'bar'}
+      };
+
+      jsonpatch.applyPatch(obj2, patches);
+      expect(obj2).toReallyEqual(obj);
+    });
+
+    it('should generate replace (empty object to empty array substitution)', function() {
+      const obj = {
+        data: {}
+      };
+
+      const observer = jsonpatch.observe(obj);
+      obj.data = []
+
+      const patches = jsonpatch.generate(observer);
+
+      const obj2 = {
+        data: {}
+      };
+
+      jsonpatch.applyPatch(obj2, patches);
+      expect(obj2).toReallyEqual(obj);
+    });
+
     it('should generate add', function() {
       const obj = {
         lastName: 'Einstein',


### PR DESCRIPTION
Avoid checking differences between objects an arrays