### PR TITLE
Fix #209 Generate only one replace action

### DIFF
--- a/module/duplex.mjs
+++ b/module/duplex.mjs
@@ -127,7 +127,7 @@ function _generate(mirror, obj, patches, path, invertible) {
         var oldVal = mirror[key];
         if (hasOwnProperty(obj, key) && !(obj[key] === undefined && oldVal !== undefined && Array.isArray(obj) === false)) {
             var newVal = obj[key];
-            if (typeof oldVal == "object" && oldVal != null && typeof newVal == "object" && newVal != null) {
+            if (typeof oldVal == "object" && oldVal != null && typeof newVal == "object" && newVal != null && Array.isArray(oldVal) === Array.isArray(newVal)) {
                 _generate(oldVal, newVal, patches, path + "/" + escapePathComponent(key), invertible);
             }
             else {

--- a/src/duplex.ts
+++ b/src/duplex.ts
@@ -163,7 +163,7 @@ function _generate(mirror, obj, patches, path, invertible) {
     if (hasOwnProperty(obj, key) && !(obj[key] === undefined && oldVal !== undefined && Array.isArray(obj) === false)) {
       var newVal = obj[key];
 
-      if (typeof oldVal == "object" && oldVal != null && typeof newVal == "object" && newVal != null) {
+      if (typeof oldVal == "object" && oldVal != null && typeof newVal == "object" && newVal != null && Array.isArray(oldVal) === Array.isArray(newVal)) {
         _generate(oldVal, newVal, patches, path + "/" + escapePathComponent(key), invertible);
       }
       else {

--- a/test/spec/duplexSpec.mjs
+++ b/test/spec/duplexSpec.mjs
@@ -937,6 +937,32 @@ describe('duplex', function() {
         });
       });
     });
+
+    // https://github.com/Starcounter-Jack/JSON-Patch/issues/209
+    it('should generate only one replace', function() {
+      var obj1 = {
+        test: [
+          { k: "xx" },
+          { k: "yy" }
+        ]
+      };
+
+      var obj2 = {
+        test: {
+          "xx": { k: "xx" },
+          "yy": { k: "yy" }
+        }
+      };
+
+      let patch = jsonpatch.compare(obj1, obj2);
+
+      expect(patch.length).toEqual(1);
+      expect(patch[0]).toEqual({
+        op: 'replace',
+        path: '/test',
+        value: obj2.test,
+      });
+    });
   });
 
   describe('apply', function() {


### PR DESCRIPTION
When comparing `Array` and `Object` will generate a replace action for the whole key.