### PR TITLE
Updated typing for deepClone method

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -33,7 +33,7 @@ export function _objectKeys(obj) {
 * @param  {any} obj value to clone
 * @return {any} cloned obj
 */
-export function _deepClone(obj) {
+export function _deepClone<T = any>(obj: T): T | null {
     switch (typeof obj) {
         case "object":
             return JSON.parse(JSON.stringify(obj)); //Faster than ES5 clone - http://jsperf.com/deep-cloning-of-objects/5


### PR DESCRIPTION
Typing for the `deepClone` function is useful to end users since it removes the need for a redundant type cast. For example:

```typescript
const newReport = deepClone(currentReport) as IReport; // current typing
const newReport = deepClone<IReport>(currentReport); // explicit typing
const newReport = deepClone(currentReport); // implicit typing
```

The added generic was given a default `any` type to maintain backwards compatibility, and the return type was set to be `T` or `null` to guarantee the change wouldn't break any repositories using the tsconfig [strictNullChecks](https://www.typescriptlang.org/tsconfig#strictNullChecks) option.

