### PR TITLE
chore(applyPatch): correct comment

### DIFF
--- a/commonjs/core.js
+++ b/commonjs/core.js
@@ -276,7 +276,7 @@ function applyPatch(document, patch, validateOperation, mutateDocument, banProto
     }
     var results = new Array(patch.length);
     for (var i = 0, length_1 = patch.length; i < length_1; i++) {
-        // we don't need to pass mutateDocument argument because if it was true, we already deep cloned the object, we'll just pass `true`
+        // we don't need to pass mutateDocument argument because if it was false, we already deep cloned the object, we'll just pass `true`
         results[i] = applyOperation(document, patch[i], validateOperation, true, banPrototypeModifications, i);
         document = results[i].newDocument; // in case root was replaced
     }


### PR DESCRIPTION
Sorry for the super tiny PR.

However in this comment, its noted that passing down the input param `mutateDocument` is unnecessary.

This is because in the case `mutateDocument` was `**true**` passing down `true` is effectively a no-op.

and in the case `mutateDocument` was `**false**` a deep clone has already taken place, so further deep clones are redundant and affect performance.

The comment had the above switched.